### PR TITLE
support btcfun

### DIFF
--- a/index.json
+++ b/index.json
@@ -19,6 +19,7 @@
   "@elizaos-plugins/plugin-autonome": "github:elizaos-plugins/plugin-autonome",
   "@elizaos-plugins/plugin-avail": "github:elizaos-plugins/plugin-avail",
   "@elizaos-plugins/plugin-avalanche": "github:elizaos-plugins/plugin-avalanche",
+  "@elizaos-plugins/plugin-btcfun": "github:elizaos-plugins/plugin-btcfun",
   "@elizaos-plugins/plugin-binance": "github:elizaos-plugins/plugin-binance",
   "@elizaos-plugins/plugin-coinbase": "github:elizaos-plugins/plugin-coinbase",
   "@elizaos-plugins/plugin-coingecko": "github:elizaos-plugins/plugin-coingecko",


### PR DESCRIPTION
## Description
Adding Btcfun Plugin to the ElizaOS plugin registry. This plugin enables import Brc20 and Runes

## Changes
- Added Btcfun Plugin entry to `index.json`
- Plugin repository: [https://github.com/fobtc/eliza-plugin-registry](https://github.com/fobtc/eliza-plugin-registry/tree/main)
