### PR TITLE
Fix: Corrected a typo on streamr git repo path

### DIFF
--- a/index.json
+++ b/index.json
@@ -5,7 +5,7 @@
   "@elizaos-plugins/client-github": "github:elizaos-plugins/client-github",
   "@elizaos-plugins/client-lens": "github:elizaos-plugins/client-lens",
   "@elizaos-plugins/client-slack": "github:elizaos-plugins/client-slack",
-  "@elizaos-plugins/client-streamr": "github.com:streamr-dev/client-streamr",
+  "@elizaos-plugins/client-streamr": "github:streamr-dev/client-streamr",
   "@elizaos-plugins/client-telegram": "github:elizaos-plugins/client-telegram",
   "@elizaos-plugins/client-twitter": "github:elizaos-plugins/client-twitter",
   "@elizaos-plugins/client-xmtp": "github:ephemeraHQ/client-xmtp",


### PR DESCRIPTION
Fix: Path is "github.com:streamr-dev/client-streamr" but should be "github:streamr-dev/client-streamr".
