### PR TITLE
feat: add plugin-trustgo (CONFLICT RESOLVED)

### DIFF
--- a/index.json
+++ b/index.json
@@ -90,5 +90,6 @@
     "@elizaos-plugins/plugin-zerion": "github:elizaos-plugins/plugin-zerion",
     "@elizaos-plugins/plugin-zksync-era": "github:elizaos-plugins/plugin-zksync-era",
     "@elizaos-plugins/plugin-omniflix": "github:elizaos-plugins/plugin-omniflix",
-    "@elizaos-plugins/plugin-ccxt": "github:pranavjadhav1363/plugin-ccxt"
+    "@elizaos-plugins/plugin-ccxt": "github:pranavjadhav1363/plugin-ccxt",
+    "@toddli/plugin-trustgo": "github:TrustaLabs/plugin-trustgo"
 }


### PR DESCRIPTION
Add plugin-trustgo to registry.

This elizaOS plugin provides actions and providers for interacting with trustgo - https://trustgo.trustalabs.ai/.

## Description

The TrustGo plugin enables fetching EVM account information from the TrustGo website and facilitates the minting of MEDIA score attestations.

## Features

- Login to TrustGo Website: Securely authenticate with TrustGo.
- Fetch Multi-Chain MEDIA Score: Retrieve MEDIA scores across multiple chains.
- Fetch User Attestations: Access user attestations.
- Mint L2 MEDIA Attestation: Mint MEDIA attestations on Layer 2.

## Installation

```bash
pnpm install @toddli/plugin-trustgo
```