### PR TITLE
re-add plugin Messari-ai-toolkit

### DIFF
--- a/index.json
+++ b/index.json
@@ -56,6 +56,7 @@
     "@elizaos-plugins/plugin-lensNetwork": "github:elizaos-plugins/plugin-lensNetwork",
     "@elizaos-plugins/plugin-letzai": "github:elizaos-plugins/plugin-letzai",
     "@elizaos-plugins/plugin-massa": "github:elizaos-plugins/plugin-massa",
+    "@elizaos-plugins/plugin-messari-ai-toolkit": "github:messari/plugin-messari-ai-toolkit",
     "@elizaos-plugins/plugin-movement": "github:elizaos-plugins/plugin-movement",
     "@elizaos-plugins/plugin-multiversx": "github:elizaos-plugins/plugin-multiversx",
     "@elizaos-plugins/plugin-near": "github:elizaos-plugins/plugin-near",


### PR DESCRIPTION
Not sure when the diffs from this [PR](https://github.com/elizaos-plugins/registry/commit/fe608b669fd76b0beae520c74df8fa3bd64a44b2) were removed, but this PR re-adds it.