### PR TITLE
feat: Add plugin-nkn

### DIFF
--- a/index.json
+++ b/index.json
@@ -93,5 +93,6 @@
     "@elizaos-plugins/plugin-omniflix": "github:elizaos-plugins/plugin-omniflix",
     "@elizaos-plugins/plugin-ccxt": "github:pranavjadhav1363/plugin-ccxt",
     "@elizaos-plugins/plugin-firecrawl": "github:tobySolutions/plugin-firecrawl",
-    "@elizaos-plugins/plugin-ATTPs": "github.com:APRO-com/plugin-ATTPs.git"
+    "@elizaos-plugins/plugin-ATTPs": "github.com:APRO-com/plugin-ATTPs.git",
+    "@elizaos-plugins/plugin-nkn": "github:nknorg/eliza-plugin-nkn"
 }


### PR DESCRIPTION
Add plugin-nkn ([https://github.com/nknorg/eliza-plugin-nkn](https://github.com/nknorg/eliza-plugin-nkn)) to registry.

This ElizaOS plugin integrates NKN ([https://nkn.org/](https://nkn.org/)) to enable communication between multiple AI agents or users.

Description

The plugin-nkn leverages the NKN protocol to facilitate messaging and communication between various AI agents and users within the Eliza framework. It supports both sending and receiving messages via a decentralized network, ensuring low latency and secure transmission.