### PR TITLE
Add plugin-youtube-to-text

### DIFF
--- a/index.json
+++ b/index.json
@@ -93,5 +93,6 @@
     "@elizaos-plugins/plugin-omniflix": "github:elizaos-plugins/plugin-omniflix",
     "@elizaos-plugins/plugin-ccxt": "github:pranavjadhav1363/plugin-ccxt",
     "@elizaos-plugins/plugin-firecrawl": "github:tobySolutions/plugin-firecrawl",
-    "@elizaos-plugins/plugin-ATTPs": "github.com:APRO-com/plugin-ATTPs.git"
+    "@elizaos-plugins/plugin-ATTPs": "github.com:APRO-com/plugin-ATTPs.git",
+    "@elizaos-plugins/plugin-youtube-to-text": "github.com:wellaios/plugin-youtube-to-text.git"
 }


### PR DESCRIPTION
Add plugin-youtube-to-text (https://github.com/wellaios/plugin-youtube-to-text.git) to registry.

This ElizaOS plugin converts YouTube videos into text.

Description

The plugin-youtube-to-text uses OpenAI's Whisper model to transcribe YouTube video links into text. Users can share a YouTube link in chat and receive an accurate text transcription of the video's content.