### PR TITLE
feat: add plugin-zapper

### DIFF
--- a/index.json
+++ b/index.json
@@ -99,6 +99,6 @@
     "@elizaos-plugins/plugin-youtube-to-text": "github:wellaios/plugin-youtube-to-text",
     "@elizaos-plugins/plugin-nkn": "github:nknorg/eliza-plugin-nkn",
     "@elizaos-plugins/plugin-viction": "github:BuildOnViction/plugin-viction",
-    "@elizaos-plugins/plugin-grix": "github:grixprotocol/plugin-grix"
-
+    "@elizaos-plugins/plugin-grix": "github:grixprotocol/plugin-grix",
+    "@elizaos-plugins/plugin-zapper": "github:ben-dh3/plugin-zapper"
 }


### PR DESCRIPTION
## Description
Adds the Zapper Plugin to the ElizaOS plugin registry. This plugin adds integration with the Zapper API.

## Changes
- Added Zapper Plugin entry to `index.json`
- Plugin repository: https://github.com/ben-dh3/plugin-zapper

## Screenshots

![Screenshot from 2025-02-22 14-13-59](https://github.com/user-attachments/assets/a016350c-6eeb-4380-bab5-c8d6d49356a2)
![Screenshot from 2025-02-22 14-14-45](https://github.com/user-attachments/assets/62ed9bcc-9f2b-41c2-b37c-f98af55f85fa)

## Configuration

```typescript
{
  "name": "MyAgent",
  "plugins": ["@elizaos/plugin-zapper"]
}
```