### PR TITLE
Add Twilio plugin to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -96,6 +96,7 @@
     "@elizaos-plugins/plugin-trustdb": "github:elizaos-plugins/plugin-trustdb",
     "@elizaos-plugins/plugin-trustgo": "github:TrustaLabs/plugin-trustgo",
     "@elizaos-plugins/plugin-tts": "github:elizaos-plugins/plugin-tts",
+    "@elizaos-plugins/plugin-twilio": "github:boolkeys/plugin-twilio",
     "@elizaos-plugins/plugin-twitter": "github:elizaos-plugins/plugin-twitter",
     "@elizaos-plugins/plugin-viction": "github:BuildOnViction/plugin-viction",
     "@elizaos-plugins/plugin-video-generation": "github:elizaos-plugins/plugin-video-generation",


### PR DESCRIPTION
# Add Twilio plugin to registry

## Description
Adding Twilio plugin to the elizaOS plugins registry. This plugin enables voice and SMS capabilities through Twilio integration.

## Background
- Previously reviewed and approved in PR elizaOS/eliza#2139
- Working implementation reference: elizaOS/eliza@9e547364e0
- Repository: https://github.com/boolkeys/plugin-twilio

## Features
- Voice call integration with Twilio
- SMS messaging capabilities
- Configurable Twilio credentials
- Easy integration with elizaOS core

## Testing
- Plugin has been tested with various Twilio features
- Successfully integrated with elizaOS core functionalities
- Previously validated in the main repository

## Related Links
- Original issue: https://github.com/elizaOS/eliza/issues/1631
- Original PR: https://github.com/elizaOS/eliza/pull/1665
- Following PR: https://github.com/elizaOS/eliza/pull/2139
- Working commit: https://github.com/elizaOS/eliza/commit/9e547364e0bed4a5f79514b1f01acb6dddf783bc

## Discord username
boolkeys
