### PR TITLE
feat: plugin t3rn executor

### DIFF
--- a/index.json
+++ b/index.json
@@ -48,6 +48,7 @@
     "@elizaos-plugins/plugin-edwin": "github:elizaos-plugins/plugin-edwin",
     "@elizaos-plugins/plugin-enso": "github:EnsoBuild/plugin-enso",
     "@elizaos-plugins/plugin-evm": "github:elizaos-plugins/plugin-evm",
+    "@elizaos-plugins/plugin-executor": "github:t3rn/plugin-t3rn-executor",
     "@elizaos-plugins/plugin-ferePro": "github:elizaos-plugins/plugin-ferePro",
     "@elizaos-plugins/plugin-firecrawl": "github:tobySolutions/plugin-firecrawl",
     "@elizaos-plugins/plugin-flow": "github:fixes-world/plugin-flow",


### PR DESCRIPTION
Public repo link: https://github.com/t3rn/plugin-t3rn-executor

adding plugin t3rn executor for release

# Registry Update Checklist

Registry:
- [x] I've made the organization @eliza-plugins
- [x] I've used github not github.com
- [x] There is no .git extension
- [x] It's placed it alphabetically in the list
- [x] I've dealt with commas properly so the list is still valid JSON

If not an eliza-plugins official repo, i.e. new plugin: 

The plugin repo has:
- [x] is publically accessible (not a private repo)
- [x] uses main as it's default branch
- [x] I have include `elizaos-plugins` in the topics in the GitHub repo settings. If the plugin is related to `AI` or `crypto`, please add those as topics as well.
- [x] add simple description in github repo
- [x] follows this convention
```
plugin-name/
├── images/
│   ├── logo.jpg        # Plugin branding logo
│   ├── banner.jpg      # Plugin banner image
├── src/
│   ├── index.ts        # Main plugin entry point
│   ├── actions/        # Plugin-specific actions
│   ├── clients/        # Client implementations
│   ├── adapters/       # Adapter implementations
│   └── types.ts        # Type definitions
│   └── environment.ts  # runtime.getSetting, zod validation
├── package.json        # Plugin dependencies
└── README.md          # Plugin documentation
```
- [x] an `images/banner.jpg` and `images/logo.jpg` and they
  - Use clear, high-resolution images
  - Keep file sizes optimized (< 500KB for logos, < 1MB for banners)
  - Follow the [elizaOS Brand Guidelines](https://github.com/elizaOS/brandkit)
  - Include alt text for accessibility
- [x] package.json has a agentConfig like the following
```json
{
  "name": "@elizaos/plugin-example",
  "version": "1.0.0",
  "agentConfig": {
    "pluginType": "elizaos:plugin:1.0.0",
    "pluginParameters": {
      "API_KEY": {
        "type": "string",
        "description": "API key for the service"
      }
    }
  }
}
```


## Discord username: teoloki

