### PR TITLE
Add @elizaos-plugins/plugin-testest to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -151,6 +151,7 @@
     "@elizaos-plugins/plugin-tee-log": "github:elizaos-plugins/plugin-tee-log",
     "@elizaos-plugins/plugin-tee-marlin": "github:elizaos-plugins/plugin-tee-marlin",
     "@elizaos-plugins/plugin-telegram": "github:elizaos-plugins/plugin-telegram",
+  "@elizaos-plugins/plugin-testest": "github:yungalgo/plugin-testest",
     "@elizaos-plugins/plugin-thirdweb": "github:elizaos-plugins/plugin-thirdweb",
     "@elizaos-plugins/plugin-ton": "github:elizaos-plugins/plugin-ton",
     "@elizaos-plugins/plugin-trn": "github:Gen3Games/plugin-trn",


### PR DESCRIPTION
This PR adds @elizaos-plugins/plugin-testest to the registry.

- Package name: @elizaos-plugins/plugin-testest
- GitHub repository: github:yungalgo/plugin-testest
- Version: 0.1.0
- Description: ElizaOS plugin for testest

Submitted by: @yungalgo