### PR TITLE
Add @yungalgo/plugin-fishsticks to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -171,4 +171,5 @@
     "@elizaos-plugins/plugin-zerion": "github:elizaos-plugins/plugin-zerion",
     "@elizaos-plugins/plugin-zksync-era": "github:elizaos-plugins/plugin-zksync-era",
     "@elizaos-plugins/plugin-zytron": "github:zypher-network/plugin-zytron"
+    "@yungalgo/plugin-fishsticks": "github:yungalgo/plugin-fishsticks",
 }


### PR DESCRIPTION
This PR adds @yungalgo/plugin-fishsticks to the registry.

- Package name: @yungalgo/plugin-fishsticks
- GitHub repository: github:yungalgo/plugin-fishsticks
- Version: 0.1.0
- Description: ElizaOS plugin for fishsticks

Submitted by: @yungalgo