### PR TITLE
Add @yungalgo/plugin-melon to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -173,4 +173,5 @@
     "@elizaos-plugins/plugin-zytron": "github:zypher-network/plugin-zytron",
     "@elizaos-plugins/plugin-cardano": "github:relipasoft/plugin-cardano",
     "@elizaos-plugins/plugin-reveel-payid": "github:r3vl/plugin-reveel-payid"
+    "@yungalgo/plugin-melon": "github:yungalgo/plugin-melon",
 }


### PR DESCRIPTION
This PR adds @yungalgo/plugin-melon to the registry.

- Package name: @yungalgo/plugin-melon
- GitHub repository: github:yungalgo/plugin-melon
- Version: 0.1.0
- Description: ElizaOS plugin for melon

Submitted by: @yungalgo