### PR TITLE
Add @mazzz/plugin-elizaos-compchembridge to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -177,4 +177,5 @@
     "@elizaos-plugins/plugin-cardano": "github:relipasoft/plugin-cardano",
     "@elizaos-plugins/plugin-reveel-payid": "github:r3vl/plugin-reveel-payid",
     "@elizaos-plugins/plugin-xmtp": "github:elizaos-plugins/plugin-xmtp"
+    "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
 }


### PR DESCRIPTION
This PR adds @mazzz/plugin-elizaos-compchembridge to the registry.

- Package name: @mazzz/plugin-elizaos-compchembridge
- GitHub repository: github:Mazzz-zzz/plugin-elizaos-compchembridge
- Version: 0.1.7
- Description: ElizaOS plugin for parsing Gaussian 16 quantum chemistry logfiles into a knowledge graph

Submitted by: @Mazzz-zzz