### PR TITLE
Add @yungalgo/plugin-barbeque to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -178,4 +178,5 @@
     "@elizaos-plugins/plugin-reveel-payid": "github:r3vl/plugin-reveel-payid",
     "@elizaos-plugins/plugin-xmtp": "github:elizaos-plugins/plugin-xmtp",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge"
+    "@yungalgo/plugin-barbeque": "github:yungalgo/plugin-barbeque",
 }


### PR DESCRIPTION
This PR adds @yungalgo/plugin-barbeque to the registry.

- Package name: @yungalgo/plugin-barbeque
- GitHub repository: github:yungalgo/plugin-barbeque
- Version: 0.1.0
- Description: ElizaOS plugin for barbeque

Submitted by: @yungalgo