### PR TITLE
Add @yungalgo/plugin-goober to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -178,4 +178,5 @@
     "@elizaos-plugins/plugin-reveel-payid": "github:r3vl/plugin-reveel-payid",
     "@elizaos-plugins/plugin-xmtp": "github:elizaos-plugins/plugin-xmtp",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge"
+    "@yungalgo/plugin-goober": "github:yungalgo/plugin-goober",
 }


### PR DESCRIPTION
This PR adds @yungalgo/plugin-goober to the registry.

- Package name: @yungalgo/plugin-goober
- GitHub repository: github:yungalgo/plugin-goober
- Version: 0.1.0
- Description: ElizaOS plugin for goober

Submitted by: @yungalgo