### PR TITLE
Add @yungalgo/plugin-gooba to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -178,4 +178,5 @@
     "@elizaos-plugins/plugin-reveel-payid": "github:r3vl/plugin-reveel-payid",
     "@elizaos-plugins/plugin-xmtp": "github:elizaos-plugins/plugin-xmtp",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge"
+    "@yungalgo/plugin-gooba": "github:yungalgo/plugin-gooba",
 }


### PR DESCRIPTION
This PR adds @yungalgo/plugin-gooba to the registry.

- Package name: @yungalgo/plugin-gooba
- GitHub repository: github:yungalgo/plugin-gooba
- Version: 0.1.0
- Description: ElizaOS plugin for gooba

Submitted by: @yungalgo