### PR TITLE
Add @yungalgo/plugin-jello to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -180,4 +180,5 @@
     "@elizaos-plugins/plugin-reveel-payid": "github:r3vl/plugin-reveel-payid",
     "@elizaos-plugins/plugin-xmtp": "github:elizaos-plugins/plugin-xmtp",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge"
+    "@yungalgo/plugin-jello": "github:yungalgo/plugin-jello",
 }


### PR DESCRIPTION
This PR adds @yungalgo/plugin-jello to the registry.

- Package name: @yungalgo/plugin-jello
- GitHub repository: github:yungalgo/plugin-jello
- Version: 0.1.0
- Description: ElizaOS plugin for jello

Submitted by: @yungalgo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new plugin entry for "@yungalgo/plugin-jello" to the plugin list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->