### PR TITLE
Add @yungalgo/plugin-jellie to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -180,4 +180,5 @@
     "@elizaos-plugins/plugin-reveel-payid": "github:r3vl/plugin-reveel-payid",
     "@elizaos-plugins/plugin-xmtp": "github:elizaos-plugins/plugin-xmtp",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge"
+    "@yungalgo/plugin-jellie": "github:yungalgo/plugin-jellie",
 }


### PR DESCRIPTION
This PR adds @yungalgo/plugin-jellie to the registry.

- Package name: @yungalgo/plugin-jellie
- GitHub repository: github:yungalgo/plugin-jellie
- Version: 0.1.0
- Description: ElizaOS plugin for jellie

Submitted by: @yungalgo