### PR TITLE
Add @bealers/plugin-mattermost to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -3,6 +3,7 @@
     "": "classes.adapters/sql",
     "": "classes.clients/twitter, discord, telegram",
     "": "classes.default/bootstrap",
+    "@bealers/plugin-mattermost": "github:bealers/plugin-mattermost",
     "@elizaos/adapter-mongodb": "github:elizaos-plugins/adapter-mongodb",
     "@elizaos/adapter-pglite": "github:elizaos-plugins/adapter-pglite",
     "@elizaos/adapter-postgres": "github:elizaos-plugins/adapter-postgres",


### PR DESCRIPTION
This PR adds @bealers/plugin-mattermost to the registry.

- Package name: @bealers/plugin-mattermost
- GitHub repository: github:bealers/plugin-mattermost
- Version: 0.1.6
- Description: Mattermost client plugin for ElizaOS - enables AI agent integration with Mattermost chat platforms

Submitted by: @bealers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new entry for "@bealers/plugin-mattermost" to the plugin index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->