### PR TITLE
Add plugin-desearch to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -182,4 +182,5 @@
     "@elizaos/plugin-xmtp": "github:elizaos-plugins/plugin-xmtp",
     "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge"
+    "plugin-desearch": "github:superdevstar50/plugin-desearch",
 }


### PR DESCRIPTION
This PR adds plugin-desearch to the registry.

- Package name: plugin-desearch
- GitHub repository: github:superdevstar50/plugin-desearch
- Version: 0.1.1
- Description: ElizaOS plugin for seamless integration with Desearch, enabling enhanced AI-driven search capabilities

Submitted by: @superdevstar50