### PR TITLE
Add plugin-desearch to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -181,5 +181,6 @@
     "@elizaos/plugin-reveel-payid": "github:r3vl/plugin-reveel-payid",
     "@elizaos/plugin-xmtp": "github:elizaos-plugins/plugin-xmtp",
     "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
-    "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge"
+    "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
+    "plugin-desearch": "github:Desearch-ai/plugin-desearch"
 }


### PR DESCRIPTION
This PR adds plugin-desearch to the registry.

- Package name: plugin-desearch
- GitHub repository: github:superdevstar50/plugin-desearch
- Version: 0.1.2
- Description: ElizaOS plugin for seamless integration with Desearch, enabling enhanced AI-driven search capabilities

Submitted by: @superdevstar50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added "plugin-desearch" to the list of available plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->