### PR TITLE
Add @manuelbarbas/plugin-fair to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -183,6 +183,7 @@
     "@elizaos/plugin-xmtp": "github:elizaos-plugins/plugin-xmtp",
     "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
     "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
+    "@manuelbarbas/plugin-fair": "github:manuelbarbas/plugin-fair",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
     "plugin-desearch": "github:Desearch-ai/plugin-desearch"
 }


### PR DESCRIPTION
This PR adds @manuelbarbas/plugin-fair to the registry.

- Package name: @manuelbarbas/plugin-fair
- GitHub repository: github:manuelbarbas/plugin-fair
- Version: 0.1.0
- Description: FAIR Network integration on ElizaOS. This plugin allow to perform encrypted on-chain operations using the ElizaOS AI Agent

Submitted by: @manuelbarbas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the "@manuelbarbas/plugin-fair" plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->