### PR TITLE
edit: plugin-bonsai published

### DIFF
--- a/index.json
+++ b/index.json
@@ -47,7 +47,6 @@
     "@elizaos/plugin-bless": "github:blessnetwork/elizaos-bless-plugin",
     "@elizaos/plugin-bnb": "github:elizaos-plugins/plugin-bnb",
     "@elizaos/plugin-bnv-me-id": "github:brand-new-vision/plugin-bnv-me-id",
-    "@elizaos/plugin-bonsai": "github:onbonsai/elizaos-plugin-bonsai",
     "@elizaos/plugin-bootstrap": "github:elizaos-plugins/plugin-bootstrap",
     "@elizaos/plugin-browser": "github:elizaos-plugins/plugin-browser",
     "@elizaos/plugin-ccxt": "github:pranavjadhav1363/plugin-ccxt",
@@ -194,5 +193,6 @@
     "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
     "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
+    "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai",
     "plugin-desearch": "github:Desearch-ai/plugin-desearch"
 }


### PR DESCRIPTION
# Registry Update Checklist

Registry:
- [x] I've made the left side of the colon of JSON entry in index.json match the potential NPM package name
- [x] I've used github not github.com
- [x] There is no .git extension
- [x] It's placed it alphabetically in the list
- [x] I've dealt with commas properly so the list is still valid JSON

## published `plugin-bonsai` to our org npm
https://www.npmjs.com/package/@onbonsai/plugin-bonsai

## original add plugin PR
https://github.com/elizaos-plugins/registry/pull/181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the plugin list to reflect the new namespace and repository location for the Bonsai plugin. The plugin is now listed under "@onbonsai" instead of "@elizaos".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->