### PR TITLE
Add plugin-coti to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -200,6 +200,6 @@
     "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
     "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai",
-    "plugin-desearch": "github:Desearch-ai/plugin-desearch"
-    "plugin-coti": "github:cuongpo/plugin-coti",
+    "plugin-desearch": "github:Desearch-ai/plugin-desearch",
+    "plugin-coti": "github:cuongpo/plugin-coti"
 }

--- a/index.json
+++ b/index.json
@@ -201,4 +201,5 @@
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
     "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai",
     "plugin-desearch": "github:Desearch-ai/plugin-desearch"
+    "plugin-coti": "github:cuongpo/plugin-coti",
 }


### PR DESCRIPTION
This PR adds plugin-coti to the registry.

- Package name: plugin-coti
- GitHub repository: github:cuongpo/plugin-coti
- Version: 0.1.0
- Description: COTI blockchain plugin for ElizaOS - enables private token operations and encrypted transactions

Submitted by: @cuongpo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the "plugin-coti" plugin, enabling integration with its features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->