### PR TITLE
Add plugin-hehe to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -200,4 +200,5 @@
     "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
     "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai"
+    "plugin-hehe": "github:ChristopherTrimboli/plugin-hehe",
 }


### PR DESCRIPTION
This PR adds plugin-hehe to the registry.

- Package name: plugin-hehe
- GitHub repository: github:ChristopherTrimboli/plugin-hehe
- Version: 0.1.0
- Description: Quick backend-only plugin template for ElizaOS

Submitted by: @ChristopherTrimboli