### PR TITLE
Add plugin-fluxpoint-kg to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -200,4 +200,5 @@
     "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
     "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai"
+    "plugin-fluxpoint-kg": "github:RolandOne/plugin-fluxpoint-kg",
 }


### PR DESCRIPTION
This PR adds plugin-fluxpoint-kg to the registry.

- Package name: plugin-fluxpoint-kg
- GitHub repository: github:RolandOne/plugin-fluxpoint-kg
- Version: 0.1.0
- Description: Quick backend-only plugin template for ElizaOS

Submitted by: @RolandOne