### PR TITLE
Add plugin-asd123 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -205,4 +205,5 @@
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
     "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai",
     "@elizaos/plugin-action-bench": "github:elizaos-plugins/plugin-action-bench"
+    "plugin-asd123": "github:yungalgo/plugin-asd123",
 }


### PR DESCRIPTION
This PR adds plugin-asd123 to the registry.

- Package name: plugin-asd123
- GitHub repository: github:yungalgo/plugin-asd123
- Version: 0.1.0
- Description: ElizaOS plugin for asd123

Submitted by: @yungalgo