### PR TITLE
Add plugin-fal-ai to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -204,7 +204,6 @@
     "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
     "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai",
-    "@elizaos/plugin-action-bench": "github:elizaos-plugins/plugin-action-bench"
     "@elizaos/plugin-action-bench": "github:elizaos-plugins/plugin-action-bench",
-    "@yungalgo/plugin-fal-ai":                "github:yungalgo/plugin-fal-ai",
+    "@yungalgo/plugin-fal-ai": "github:yungalgo/plugin-fal-ai"
 }


### PR DESCRIPTION
This PR adds plugin-fal-ai to the registry.

- Package name: plugin-fal-ai
- GitHub repository: github:yungalgo/plugin-fal-ai
- Version: 0.1.0
- Description: ElizaOS plugin for fal-ai

Submitted by: @yungalgo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Fal AI plugin to the public plugin catalog for discovery and installation.
  * Users can enable Fal AI capabilities through the plugin system like other plugins.
  * The plugin is listed alongside existing entries without impacting current plugins’ availability or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->