### PR TITLE
Add @testorg-eliza/plugin-sourcegraph to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -176,6 +176,7 @@
    "@elizaos/plugin-tee-marlin":"github:elizaos-plugins/plugin-tee-marlin",
    "@elizaos/plugin-telegram":"github:elizaos-plugins/plugin-telegram",
    "@elizaos/plugin-thirdweb":"github:elizaos-plugins/plugin-thirdweb",
+    "@testorg-eliza/plugin-sourcegraph": "github:0xbbjoker/plugin-sourcegraph",
    "@token-metrics/plugin-tokenmetrics":"github:token-metrics/plugin-tokenmetrics",
    "@elizaos/plugin-ton":"github:elizaos-plugins/plugin-ton",
    "@elizaos/plugin-trn":"github:Gen3Games/plugin-trn",


### PR DESCRIPTION
This PR adds @testorg-eliza/plugin-sourcegraph to the registry.

- Package name: @testorg-eliza/plugin-sourcegraph
- GitHub repository: github:0xbbjoker/plugin-sourcegraph
- Version: 0.1.0
- Description: Sourcegraph integration plugin for ElizaOS - provides code search and repository exploration

Submitted by: @0xbbjoker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a public mapping for the Sourcegraph plugin, enabling installation and use via the alias "@testorg-eliza/plugin-sourcegraph" pointing to a GitHub source. No changes to existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->