### PR TITLE
Add plugin-delta to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -206,5 +206,5 @@
    "@onbonsai/plugin-bonsai":"github:onbonsai/plugin-bonsai",
    "@theschein/plugin-polymarket":"github:Okay-Bet/plugin-polymarket",
    "plugin-connections": "github:mascotai/plugin-connections",
-    "plugin-delta": "github:1BDO/plugin-delta"
+    "@1BDO/plugin-delta": "github:1BDO/plugin-delta"
 }


### PR DESCRIPTION
This PR adds plugin-delta to the registry.

- Package name: plugin-delta
- GitHub repository: github:1BDO/plugin-delta
- Version: 0.1.0
- Description: Delta Exchange Eliza Plugin

Submitted by: @1BDO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the “plugin-delta” entry to the public plugin registry, making it discoverable, installable, and usable.

* **Chores**
  * Updated registry formatting to accommodate the new entry without changing existing mappings or behavior.
  * Appended the new plugin while preserving current entries and values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->