### PR TITLE
Add plugin-red-jello to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -204,5 +204,6 @@
     "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
     "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
     "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai",
-    "@elizaos/plugin-action-bench": "github:elizaos-plugins/plugin-action-bench"
+    "@elizaos/plugin-action-bench": "github:elizaos-plugins/plugin-action-bench",
+    "plugin-red-jello": "github:yungalgo/plugin-red-jello"
 }


### PR DESCRIPTION
This PR adds plugin-red-jello to the registry.

- Package name: plugin-red-jello
- GitHub repository: github:yungalgo/plugin-red-jello
- Version: 0.1.0
- Description: Quick backend-only plugin template for ElizaOS

Submitted by: @yungalgo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added the “Red Jello” plugin to the public plugin catalog, making it available for discovery and installation through the standard plugin workflow.

* Chores
  * Updated the plugin catalog entries to include the new plugin and ensure consistent formatting across listings.

* Notes
  * No other user-facing changes were introduced in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->