### PR TITLE
Add plugin-green-jello to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -205,5 +205,6 @@
    "@mascotai/plugin-connections":"github:mascotai/plugin-connections",
    "@onbonsai/plugin-bonsai":"github:onbonsai/plugin-bonsai",
    "@theschein/plugin-polymarket":"github:Okay-Bet/plugin-polymarket",
-   "plugin-connections": "github:mascotai/plugin-connections"
+   "plugin-connections": "github:mascotai/plugin-connections",
+    "plugin-green-jello": "github:yungalgo/plugin-green-jello"
 }


### PR DESCRIPTION
This PR adds plugin-green-jello to the registry.

- Package name: plugin-green-jello
- GitHub repository: github:yungalgo/plugin-green-jello
- Version: 0.1.0
- Description: Quick backend-only plugin template for ElizaOS

Submitted by: @yungalgo