### PR TITLE
Add plugin-yellow-jello to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -205,5 +205,6 @@
    "@mascotai/plugin-connections":"github:mascotai/plugin-connections",
    "@onbonsai/plugin-bonsai":"github:onbonsai/plugin-bonsai",
    "@theschein/plugin-polymarket":"github:Okay-Bet/plugin-polymarket",
-   "plugin-connections": "github:mascotai/plugin-connections"
+   "plugin-connections": "github:mascotai/plugin-connections",
+    "plugin-yellow-jello": "github:yungalgo/plugin-yellow-jello"
 }


### PR DESCRIPTION
This PR adds plugin-yellow-jello to the registry.

- Package name: plugin-yellow-jello
- GitHub repository: github:yungalgo/plugin-yellow-jello
- Version: 0.1.0
- Description: Quick backend-only plugin template for ElizaOS

Submitted by: @yungalgo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Yellow Jello” plugin to the plugin catalog, making it discoverable and installable for users.
  * Ensures seamless integration alongside existing plugins, enabling immediate use without additional configuration.
  * Improves overall plugin coverage so users can extend functionality with the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->