### PR TITLE
Add plugin-greem to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -205,5 +205,6 @@
    "@mascotai/plugin-connections":"github:mascotai/plugin-connections",
    "@onbonsai/plugin-bonsai":"github:onbonsai/plugin-bonsai",
    "@theschein/plugin-polymarket":"github:Okay-Bet/plugin-polymarket",
-   "plugin-connections": "github:mascotai/plugin-connections"
+   "plugin-connections": "github:mascotai/plugin-connections",
+    "plugin-greem": "github:yungalgo/plugin-greem"
 }


### PR DESCRIPTION
This PR adds plugin-greem to the registry.

- Package name: plugin-greem
- GitHub repository: github:yungalgo/plugin-greem
- Version: 0.1.0
- Description: Quick backend-only plugin template for ElizaOS

Submitted by: @yungalgo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced the “Greem” plugin, now available for users to discover and install.
- Chores
  - Updated the public plugin index to include the new entry while preserving all existing mappings and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->