### PR TITLE
Add plugin-greepy to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -205,5 +205,6 @@
    "@mascotai/plugin-connections":"github:mascotai/plugin-connections",
    "@onbonsai/plugin-bonsai":"github:onbonsai/plugin-bonsai",
    "@theschein/plugin-polymarket":"github:Okay-Bet/plugin-polymarket",
-   "plugin-connections": "github:mascotai/plugin-connections"
+   "plugin-connections": "github:mascotai/plugin-connections",
+    "plugin-greepy": "github:yungalgo/plugin-greepy"
 }


### PR DESCRIPTION
This PR adds plugin-greepy to the registry.

- Package name: plugin-greepy
- GitHub repository: github:yungalgo/plugin-greepy
- Version: 0.1.0
- Description: Quick backend-only plugin template for ElizaOS

Submitted by: @yungalgo