### PR TITLE
Add plugin-groopy to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -205,5 +205,6 @@
    "@mascotai/plugin-connections":"github:mascotai/plugin-connections",
    "@onbonsai/plugin-bonsai":"github:onbonsai/plugin-bonsai",
    "@theschein/plugin-polymarket":"github:Okay-Bet/plugin-polymarket",
-   "plugin-connections": "github:mascotai/plugin-connections"
+   "plugin-connections": "github:mascotai/plugin-connections",
+    "plugin-groopy": "github:yungalgo/plugin-groopy"
 }


### PR DESCRIPTION
This PR adds plugin-groopy to the registry.

- Package name: plugin-groopy
- GitHub repository: github:yungalgo/plugin-groopy
- Version: 0.1.0
- Description: Quick backend-only plugin template for ElizaOS

Submitted by: @yungalgo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Groopy plugin to the plugin catalog, making it available for discovery and installation through the registry.
  * Users can now enable and use Groopy alongside existing plugins in supported workflows and integrations.
  * Improves overall plugin ecosystem by expanding available options without requiring manual configuration from end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->