### PR TITLE
Add plugin-grappy to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -205,5 +205,6 @@
    "@mascotai/plugin-connections":"github:mascotai/plugin-connections",
    "@onbonsai/plugin-bonsai":"github:onbonsai/plugin-bonsai",
    "@theschein/plugin-polymarket":"github:Okay-Bet/plugin-polymarket",
-   "plugin-connections": "github:mascotai/plugin-connections"
+   "plugin-connections": "github:mascotai/plugin-connections",
+    "plugin-grappy": "github:yungalgo/plugin-grappy"
 }


### PR DESCRIPTION
This PR adds plugin-grappy to the registry.

- Package name: plugin-grappy
- GitHub repository: github:yungalgo/plugin-grappy
- Version: 0.1.0
- Description: Quick backend-only plugin template for ElizaOS

Submitted by: @yungalgo