### PR TITLE
Add @yungalgo/plugin-gorpi to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -205,5 +205,6 @@
    "@mascotai/plugin-connections":"github:mascotai/plugin-connections",
    "@onbonsai/plugin-bonsai":"github:onbonsai/plugin-bonsai",
    "@theschein/plugin-polymarket":"github:Okay-Bet/plugin-polymarket",
+    "@yungalgo/plugin-gorpi": "github:yungalgo/plugin-gorpi",
    "plugin-connections": "github:mascotai/plugin-connections"
 }


### PR DESCRIPTION
This PR adds @yungalgo/plugin-gorpi to the registry.

- Package name: @yungalgo/plugin-gorpi
- GitHub repository: github:yungalgo/plugin-gorpi
- Version: 0.1.0
- Description: Quick backend-only plugin template for ElizaOS

Submitted by: @yungalgo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public availability of the "@yungalgo/plugin-gorpi" plugin. Users can discover and install it via the plugin registry.
  * This is an additive update; existing plugins and configurations remain unchanged.
  * Fully backward-compatible with no action required for current users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->