### PR TITLE
Add @yungalgo/plugin-karma to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -205,5 +205,6 @@
    "@mascotai/plugin-connections":"github:mascotai/plugin-connections",
    "@onbonsai/plugin-bonsai":"github:onbonsai/plugin-bonsai",
    "@theschein/plugin-polymarket":"github:Okay-Bet/plugin-polymarket",
+    "@yungalgo/plugin-karma": "github:yungalgo/plugin-karma",
    "plugin-connections": "github:mascotai/plugin-connections"
 }


### PR DESCRIPTION
This PR adds @yungalgo/plugin-karma to the registry.

- Package name: @yungalgo/plugin-karma
- GitHub repository: github:yungalgo/plugin-karma
- Version: 0.1.0
- Description: Quick backend-only plugin template for ElizaOS

Submitted by: @yungalgo