### PR TITLE
Add plugin-octav to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -206,5 +206,6 @@
    "@onbonsai/plugin-bonsai":"github:onbonsai/plugin-bonsai",
    "@standujar/plugin-composio":"github:standujar/plugin-composio",
    "@theschein/plugin-polymarket":"github:Okay-Bet/plugin-polymarket",
-   "plugin-connections": "github:mascotai/plugin-connections"
+   "plugin-connections": "github:mascotai/plugin-connections",
+   "plugin-octav": "github:wpoulin/plugin-octav"
 }


### PR DESCRIPTION
Registry todo
- [x] add to `index.json` - alphabetical order

repo todo
- [x] Images/brand (logo + banner)
- [x] main is the default branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Octav plugin to the public plugin index, enabling easy discovery and installation through the standard plugin mechanism.
  * Users can now reference “plugin-octav” alongside existing plugins without additional configuration.

* **Chores**
  * Minor index formatting adjustments to accommodate the new entry with no impact on functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->