### PR TITLE
Add @leopham/plugin-u2u to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -176,6 +176,7 @@
    "@elizaos/plugin-tee-marlin":"github:elizaos-plugins/plugin-tee-marlin",
    "@elizaos/plugin-telegram":"github:elizaos-plugins/plugin-telegram",
    "@elizaos/plugin-thirdweb":"github:elizaos-plugins/plugin-thirdweb",
+    "@leopham/plugin-u2u": "github:HongThaiPham/plugin-u2u",
    "@token-metrics/plugin-tokenmetrics":"github:token-metrics/plugin-tokenmetrics",
    "@elizaos/plugin-ton":"github:elizaos-plugins/plugin-ton",
    "@elizaos/plugin-trn":"github:Gen3Games/plugin-trn",


### PR DESCRIPTION
This PR adds @leopham/plugin-u2u to the registry.

- Package name: @leopham/plugin-u2u
- GitHub repository: github:HongThaiPham/plugin-u2u
- Version: 0.1.0
- Description: U2U blockchain plugin for ElizaOS - wallet management, transactions, and smart contract interactions

Submitted by: @HongThaiPham