### PR TITLE
fix: update token metrics package name from @token-metrics to @token-metrics-ai

### DIFF
--- a/index.json
+++ b/index.json
@@ -176,7 +176,7 @@
    "@elizaos/plugin-tee-marlin":"github:elizaos-plugins/plugin-tee-marlin",
    "@elizaos/plugin-telegram":"github:elizaos-plugins/plugin-telegram",
    "@elizaos/plugin-thirdweb":"github:elizaos-plugins/plugin-thirdweb",
-   "@token-metrics/plugin-tokenmetrics":"github:token-metrics/plugin-tokenmetrics",
+   "@token-metrics-ai/plugin-tokenmetrics":"github:token-metrics/plugin-tokenmetrics",
    "@elizaos/plugin-ton":"github:elizaos-plugins/plugin-ton",
    "@elizaos/plugin-trn":"github:Gen3Games/plugin-trn",
    "@elizaos/plugin-trustgo":"github:TrustaLabs/plugin-trustgo",


### PR DESCRIPTION
## Issue
The package name for the token metrics plugin was referencing the old organization namespace  instead of the updated .

## Changes
- Updated the package name in  from  to 
- This ensures the registry points to the correct GitHub organization for the plugin

## Impact
This fix ensures that users can properly install and use the token metrics plugin by referencing the correct package namespace that matches the updated GitHub organization.