### PR TITLE
feat: Add @elizaos/plugin-relay to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -152,6 +152,7 @@
    "@elizaos/plugin-raiinmaker":"github:Coiin-Blockchain/plugin-raiinmaker",
    "@elizaos/plugin-recall":"github:recallnet/plugin-recall",
    "@elizaos/plugin-redpill":"github:elizaos-plugins/plugin-redpill",
+   "@elizaos/plugin-relay":"github:elizaos-plugins/plugin-relay",
    "@elizaos/plugin-reveel-payid":"github:r3vl/plugin-reveel-payid",
    "@elizaos/plugin-rss3":"github:rss3-network/elizaos-plugin-rss3",
    "@elizaos/plugin-safe":"github:5afe/plugin-safe",


### PR DESCRIPTION
## Description

This PR adds the @elizaos/plugin-relay package to the ElizaOS plugin registry.

## Changes
- Added `@elizaos/plugin-relay` entry pointing to `github:elizaos-plugins/plugin-relay` in alphabetical order in index.json

## Purpose
This addition allows users to discover and install the plugin-relay package through the ElizaOS plugin registry system.

## Package Source
- Repository: https://github.com/elizaos-plugins/plugin-relay

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `@elizaos/plugin-relay` to the plugin registry in `index.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f668416d79b589993b170d198c1cfc3736e58ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added the Relay plugin to the public plugin registry, enabling easy discovery and installation via “@elizaos/plugin-relay”.
  - No changes required for existing setups; compatible with current configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->