### PR TITLE
Add @pyboom/plugin-moralis-v2 to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -177,6 +177,7 @@
    "@elizaos/plugin-tee-marlin":"github:elizaos-plugins/plugin-tee-marlin",
    "@elizaos/plugin-telegram":"github:elizaos-plugins/plugin-telegram",
    "@elizaos/plugin-thirdweb":"github:elizaos-plugins/plugin-thirdweb",
+    "@pyboom/plugin-moralis-v2": "github:matteo-brandolino/plugin-moralis-v2",
    "@token-metrics-ai/plugin-tokenmetrics":"github:token-metrics/plugin-tokenmetrics",
    "@elizaos/plugin-ton":"github:elizaos-plugins/plugin-ton",
    "@elizaos/plugin-trn":"github:Gen3Games/plugin-trn",


### PR DESCRIPTION
This PR adds @pyboom/plugin-moralis-v2 to the registry.

- Package name: @pyboom/plugin-moralis-v2
- GitHub repository: github:matteo-brandolino/plugin-moralis-v2
- Version: 2.0.0
- Description: Moralis DeFi plugin for ElizaOS - provides real-time Solana blockchain data

Submitted by: @matteo-brandolino

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Moralis v2 plugin to the public plugin catalog, making it discoverable and installable by name.
  * Provides access to the latest Moralis Web3 capabilities through a streamlined setup.
  * Available alongside existing plugins in the catalog for easy discovery and integration.
  * No changes required for existing setups; simply reference the new plugin to start using it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->