### PR TITLE
feat: add plugin-farcaster-local-hub

### DIFF
--- a/index.json
+++ b/index.json
@@ -77,6 +77,7 @@
    "@elizaos/plugin-evm":"github:elizaos-plugins/plugin-evm",
    "@elizaos/plugin-executor":"github:t3rn/plugin-t3rn-executor",
    "@elizaos/plugin-farcaster":"github:elizaos-plugins/plugin-farcaster",
+   "@elizaos/plugin-farcaster-local-hub":"github:AntoineVergne/plugin-farcaster-local-hub",
    "@elizaos/plugin-ferePro":"github:elizaos-plugins/plugin-ferePro",
    "@elizaos/plugin-firecrawl":"github:tobySolutions/plugin-firecrawl",
    "@elizaos/plugin-flow":"github:fixes-world/plugin-flow",


### PR DESCRIPTION
Self-hosted Farcaster plugin using local Snapchain/Hubble hub. No Neynar or external API dependencies.

Includes fixes for:
- Farcaster timestamp epoch (Jan 1, 2021)
- Hub API reverse=true for recent data first

Generated with love by a collaboration between a Human and a Synthetic intelligence (Antoine & Claude)

 ## Key Features
  - Direct hub communication via gRPC (writes) and HTTP (reads)
  - No external API costs or dependencies
  - Includes Farcaster timestamp epoch fix (Jan 1, 2021)
  - Hub API reverse=true fix for recent data first
  - Automatic mention detection and channel scanning
  - Rate limiting and daily quotas

  ## Why This Plugin?

Enables fully self-hosted Farcaster agents without relying on Neynar, reducing costs and improving decentralization.

## Registry Update Checklist
If not an eliza-plugins official repo, i.e. new plugin: 

The plugin repo has:
- [x ] is publically accessible (not a private repo)
- [ X] uses main as it's default branch
- [X] I have include `elizaos-plugins` in the topics in the GitHub repo settings. If the plugin is related to `AI` or `crypto`, please add those as topics as well.
- [X ] add simple description in github repo
- [ X] follows this convention
```
plugin-name/
├── images/
│   ├── logo.jpg        # Plugin branding logo
│   ├── banner.jpg      # Plugin banner image
├── src/
│   ├── index.ts        # Main plugin entry point
│   ├── actions/        # Plugin-specific actions
│   ├── clients/        # Client implementations
│   ├── adapters/       # Adapter implementations
│   └── types.ts        # Type definitions
│   └── environment.ts  # runtime.getSetting, zod validation
├── package.json        # Plugin dependencies
└── README.md          # Plugin documentation
```
- [ ] an `images/banner.jpg` and `images/logo.jpg` and they
  - Use clear, high-resolution images
  - Keep file sizes optimized (< 500KB for logos, < 1MB for banners)
  - Follow the [elizaOS Brand Guidelines](https://github.com/elizaOS/brandkit)
  - Include alt text for accessibility
- [ ] package.json has a agentConfig like the following
```json
{
  "name": "@myNpmOrg/plugin-example",
  "version": "1.0.0",
  "agentConfig": {
    "pluginType": "elizaos:plugin:1.0.0",
    "pluginParameters": {
      "API_KEY": {
        "type": "string",
        "description": "API key for the service"
      }
    }
  }
}
```

<!-- If you are on Discord, please join https://discord.gg/elizaOS and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## antoinevergne

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded plugin registry with Farcaster Local Hub plugin availability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->