### PR TITLE
registry: add plugin-kamiyo-trust

### DIFF
--- a/index.json
+++ b/index.json
@@ -126,6 +126,7 @@
    "@elizaos/plugin-irys": "github:elizaos-plugins/plugin-irys",
    "@elizaos/plugin-isaacx": "github:isaacx0/plugin-isaacx",
    "@elizaos/plugin-kaia": "github:kaiachain/kaia-eliza-plugin",
+   "@elizaos/plugin-kamiyo-trust": "github:kamiyo-ai/plugin-kamiyo-trust",
    "@elizaos/plugin-knowledge": "github:elizaos-plugins/plugin-knowledge",
    "@elizaos/plugin-lensNetwork": "github:elizaos-plugins/plugin-lensNetwork",
    "@elizaos/plugin-letzai": "github:elizaos-plugins/plugin-letzai",


### PR DESCRIPTION
Adds @elizaos/plugin-kamiyo-trust (github:kamiyo-ai/plugin-kamiyo-trust) to the registry.

Validation:
- Repo is public: https://github.com/kamiyo-ai/plugin-kamiyo-trust (git ls-remote succeeds)
- Only index.json changed; entry remains alphabetically sorted

Note: `claude-review` is currently failing on fork PRs due to OIDC token availability; workflow fix proposed in elizaos-plugins/registry#260.
