### PR TITLE
ci: fix claude-review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
+      issues: read
       id-token: write
     
     steps:
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -52,18 +52,16 @@ jobs:
             2. Changes must follow the registry format specified in the README
             3. JSON must be valid and maintain alphabetical sorting
             4. No duplicate entries
-            5. Validate that packages and repositories actually exist
-            
+            5. Validate that referenced GitHub repositories exist and are publicly accessible
+
             **Validation Steps:**
             For each new registry entry, use the available tools to verify:
             
-            - **NPM Package Validation**: Run `npm view @package-name` to check if the NPM package exists
-            - **GitHub Repository Validation**: Use `curl -I https://github.com/org/repo` or `git ls-remote https://github.com/org/repo.git` to verify the GitHub repository exists and is accessible
-            
+            - **GitHub Repository Validation**: Verify the GitHub repo exists and is public (and ideally uses `main` as default branch)
+
             **Review Actions:**
             - If other files are modified: Reject and ask contributor to only modify index.json
             - If format is incorrect: Reference the "Registry Format" section in README
-            - If NPM package doesn't exist: Ask contributor to publish package to NPM first or correct the package name
             - If GitHub repository doesn't exist or is inaccessible: Ask contributor to verify the repository URL and ensure it's public
             - If everything is correct: Approve and welcome the contributor
             
@@ -86,8 +84,7 @@ jobs:
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
           
-          # Enable tools for validation
-          allowed_tools: "Bash(npm view),Bash(curl),Bash(git ls-remote)"
+          disallowed_tools: "Bash"
           
           # Optional: Skip review for certain conditions
           # if: |


### PR DESCRIPTION
# Registry Update Checklist

Registry:
- [ ] I've made the left side of the colon of JSON entry in index.json match the potential NPM package name (N/A)
- [ ] I've used github not github.com (N/A)
- [ ] There is no .git extension (N/A)
- [ ] It's placed it alphabetically in the list (N/A)
- [ ] I've dealt with commas properly so the list is still valid JSON (N/A)

If not an eliza-plugins official repo, i.e. new plugin:

The plugin repo has:
- [ ] is publically accessible (not a private repo) (N/A)
- [ ] uses main as it's default branch (N/A)
- [ ] I have include `elizaos-plugins` in the topics in the GitHub repo settings. If the plugin is related to `AI` or `crypto`, please add those as topics as well. (N/A)
- [ ] add simple description in github repo (N/A)
- [ ] follows this convention (N/A)
- [ ] an `images/banner.jpg` and `images/logo.jpg` (N/A)
- [ ] package.json has a agentConfig (N/A)

## Change

Fixes the `claude-review` workflow failing on fork PRs (OIDC token retrieval / secrets unavailable with `pull_request`).

## Security / Hardening

- Use `pull_request_target` to allow OIDC + secrets.
- Checkout the PR base SHA and disable `persist-credentials` (avoid executing untrusted fork code).
- Disallow `Bash` tool usage inside Claude to reduce prompt-injection / command-injection risk.
- Pin `anthropics/claude-code-action` to a commit SHA.
- Reduce permissions (`issues: read`, keep `pull-requests: write`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded CI triggers to additional pull-request events (including reopened).
  * Elevated workflow permissions for pull-request operations.
  * Improved checkout to use base commit references and avoid persisting credentials.
  * Updated CI action pinning to a fixed version.
  * Clarified validation messaging to emphasize repository existence and public accessibility.
  * Simplified checks to verify referenced GitHub repositories’ accessibility and removed allowance for Bash tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->