### PR TITLE
Add @elizaos/plugin-buzz-bd

### DIFF
--- a/index.json
+++ b/index.json
@@ -61,6 +61,7 @@
    "@elizaos/plugin-bnv-me-id": "github:brand-new-vision/plugin-bnv-me-id",
    "@elizaos/plugin-bootstrap": "github:elizaos-plugins/plugin-bootstrap",
    "@elizaos/plugin-browser": "github:elizaos-plugins/plugin-browser",
+   "@elizaos/plugin-buzz-bd": "github:buzzbysolcex/plugin-buzz-bd",
    "@elizaos/plugin-cardano": "github:relipasoft/plugin-cardano",
    "@elizaos/plugin-ccxt": "github:pranavjadhav1363/plugin-ccxt",
    "@elizaos/plugin-cerebras": "github:Xayaan/plugin-cerebras",


### PR DESCRIPTION
## Plugin: @elizaos/plugin-buzz-bd

Autonomous BD intelligence from Buzz BD Agent — 15-source token scoring, AIXBT momentum, wallet forensics, and listing pipeline for the elizaOS agent ecosystem.

**Repository:** https://github.com/buzzbysolcex/plugin-buzz-bd

**Actions (4):**
- BUZZ_TOKEN_INTELLIGENCE — Full token analysis with 15-source cross-reference
- BUZZ_LISTING_PROSPECTS — Current hot prospects from BD pipeline
- BUZZ_AGENT_STATUS — Operational health and ERC-8004 info
- BUZZ_MOMENTUM_SCAN — AIXBT trending tokens and surge detection

**Identity:** ERC-8004 registered — Ethereum #25045, Base #17483
**Operator:** SolCex Exchange
**Infrastructure:** Akash Network (24/7)
**Assets:** logo.jpg (400x400) + banner.jpg (1280x640) included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A new plugin has been added to the plugin registry and is now available for installation and use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers a new community plugin `@elizaos/plugin-buzz-bd` by adding a single entry to `index.json` pointing to the `buzzbysolcex/plugin-buzz-bd` GitHub repository.

- Adds `"@elizaos/plugin-buzz-bd": "github:buzzbysolcex/plugin-buzz-bd"` to the plugin registry
- Entry is correctly placed in alphabetical order between `plugin-browser` and `plugin-cardano`
- Follows the established `github:owner/repo` format convention used by all other entries
- JSON structure remains valid with no syntax issues
- No naming conflicts with existing plugins in the registry

<h3>Confidence Score: 4/5</h3>

- This PR is a minimal, low-risk registry addition that follows established conventions.
- The change is a single-line addition to a JSON registry file. The entry follows the correct format, is alphabetically ordered, and introduces no conflicts. The only reason this is not a 5 is that external plugin repositories should ideally be verified for valid package.json and elizaOS core compatibility before merging, which is outside the scope of this diff review.
- No files require special attention. The external repository `buzzbysolcex/plugin-buzz-bd` should be verified for a valid package.json with an `@elizaos/core` dependency.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| index.json | Adds a single new entry `@elizaos/plugin-buzz-bd` pointing to `github:buzzbysolcex/plugin-buzz-bd`. The entry is correctly placed in alphabetical order, follows the `github:owner/repo` format convention, and the JSON remains valid. |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A["PR: Add plugin-buzz-bd to index.json"] --> B["index.json updated"]
    B --> C["CI: generate-registry.js runs"]
    C --> D["Fetches GitHub repo info\nbuzzbysolcex/plugin-buzz-bd"]
    C --> E["Fetches npm metadata\n@elizaos/plugin-buzz-bd"]
    C --> F["Reads package.json\nfrom repo branches"]
    D --> G["Determines version support\nv0 / v1 compatibility"]
    E --> G
    F --> G
    G --> H["generated-registry.json\nupdated with full metadata"]
```

<sub>Last reviewed commit: e725cc2</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->