### PR TITLE
Add micronoise-eliza-plugin - token swap via x402 payments

### DIFF
--- a/index.json
+++ b/index.json
@@ -240,5 +240,6 @@
    "plugin-connections": "github:mascotai/plugin-connections",
    "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
    "plugin-octav": "github:wpoulin/plugin-octav",
-   "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402"
+   "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402",
+   "micronoise-eliza-plugin": "github:dontonon/micronoise-eliza-plugin"
 }


### PR DESCRIPTION
## Description
Add micronoise-eliza-plugin to the registry.

This plugin enables ElizaOS agents to swap tokens via x402 micro-payments on Base chain.

## Features
- SWAP_TOKEN action for executing swaps
- GET_QUOTE for pricing
- x402 payment integration
- Base chain + Uniswap V3

## Package
- npm: micronoise-eliza-plugin
- GitHub: dontonon/micronoise-eliza-plugin
- Demo: micronoise.vercel.app/swap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added micronoise-eliza-plugin to the available plugin registry, expanding the plugin ecosystem with new capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `micronoise-eliza-plugin` to the ElizaOS plugin registry. The plugin enables token swaps via x402 micro-payments on the Base chain using Uniswap V3.

- The new entry is valid JSON and follows the `"name": "github:org/repo"` format
- **Sorting issue**: The entry is appended at the end of the file but should be placed before the `plugin-*` entries to maintain alphabetical order, as required by the contributing guidelines and PR checklist

<h3>Confidence Score: 3/5</h3>

- Minimal-risk change adding a single registry entry, but it violates the alphabetical sorting requirement
- The change is a single-line addition to index.json which is low risk. The JSON is valid and the entry format is correct. However, the entry is not placed in alphabetical order as required by the repository's contributing guidelines and PR template checklist, which warrants a request for changes.
- `index.json` — the new entry needs to be moved to the correct alphabetical position (before the `plugin-*` entries)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| index.json | Adds `micronoise-eliza-plugin` registry entry. The JSON is valid and format is correct, but the entry is not placed in alphabetical order as required by contributing guidelines — it should appear before the `plugin-*` entries. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: Add micronoise-eliza-plugin] --> B[index.json modified]
    B --> C[New entry added at end of file]
    C --> D{Alphabetically sorted?}
    D -->|No| E["'micronoise-eliza-plugin' should come before 'plugin-*' entries"]
    E --> F[Move entry to correct position]
    D -->|Yes| G[GitHub Action triggers]
    F --> G
    G --> H[generated-registry.json auto-updated]
    H --> I[Plugin available in ElizaOS CLI]
```

<sub>Last reviewed commit: 77da975</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->