### PR TITLE
Add @x402-api/elizaos-plugin — DeFi data API with x402 micropayments

### DIFF
--- a/index.json
+++ b/index.json
@@ -365,6 +365,7 @@
   "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
+  "@x402-api/elizaos-plugin": "github:fernsugi/x402-api-server#main:elizaos-plugin",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",


### PR DESCRIPTION
## Plugin: @x402-api/elizaos-plugin

**NPM:** https://www.npmjs.com/package/@x402-api/elizaos-plugin  
**Source:** https://github.com/fernsugi/x402-api-server/tree/main/elizaos-plugin

This PR adds a single registry mapping:

```json
"@x402-api/elizaos-plugin": "github:fernsugi/x402-api-server#main:elizaos-plugin"
```

### What it does

Gives ElizaOS agents access to x402-gated DeFi data endpoints on Base, including:

- price feed
- gas tracker
- DEX quotes
- whale tracker
- yield scanner
- funding rates
- token scanner
- wallet profiler

### Package details

- Published on npm as `@x402-api/elizaos-plugin@1.0.1`
- Package source lives in the monorepo subdirectory `elizaos-plugin/`
- README, LICENSE, and examples are included in that package
- Uses `@elizaos/core` as a peer dependency
- Public MIT license

This refresh addresses the earlier subdirectory-path concern and keeps the PR diff to one `index.json` entry.
