### PR TITLE
Add @liqdlad/plugin-a2a-swap to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -226,6 +226,7 @@
    "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
    "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
    "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
+    "@liqdlad/plugin-a2a-swap": "github:liqdlad-rgb/plugin-a2a-swap",
    "@mascotai/plugin-connections": "github:mascotai/plugin-connections",
    "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
    "@nuggetslife/plugin-nuggets": "github:NuggetsLtd/eliza-plugin-nuggets",


### PR DESCRIPTION
This PR adds @liqdlad/plugin-a2a-swap to the registry.

- Package name: @liqdlad/plugin-a2a-swap
- GitHub repository: github:liqdlad-rgb/plugin-a2a-swap
- Version: 0.1.1
- Description: A2A-Swap plugin for ElizaOS — autonomous token swaps and liquidity management on Solana via a constant-product AMM built for AI agents

Submitted by: @liqdlad-rgb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new plugin to the available registry: A2A Swap. This plugin is now accessible within the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `@liqdlad/plugin-a2a-swap` plugin to the registry, pointing to `github:liqdlad-rgb/plugin-a2a-swap`.

**Key Changes:**
- New plugin entry added in alphabetically correct position
- Entry follows the expected format of `@npm-package-name: github:org/repo`
- Uses `github:` prefix (not `github.com`)
- No `.git` extension present

**Issues Found:**
- Minor indentation inconsistency (4 spaces instead of 3)

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing minor indentation issue
- The PR correctly adds a single plugin entry to the registry in the proper alphabetical position with correct formatting. The only issue is a minor indentation inconsistency that should be corrected to maintain code consistency.
- No files require special attention after fixing the indentation

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| index.json | Added `@liqdlad/plugin-a2a-swap` entry with minor indentation issue |

</details>



<sub>Last reviewed commit: b63ee7f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->