### PR TITLE
feat: add @knowmint/eliza-plugin

### DIFF
--- a/index.json
+++ b/index.json
@@ -225,7 +225,7 @@
    "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
    "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
    "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
-   "@knowmint/eliza-plugin": "github:Sou0327/knowledge_market",
+   "@knowmint/eliza-plugin": "github:Sou0327/knowmint-eliza-plugin",
    "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
    "@mascotai/plugin-connections": "github:mascotai/plugin-connections",
    "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",


### PR DESCRIPTION
## Add @knowmint/eliza-plugin

**npm**: [@knowmint/eliza-plugin](https://www.npmjs.com/package/@knowmint/eliza-plugin)
**GitHub**: [Sou0327/knowledge_market](https://github.com/Sou0327/knowledge_market/tree/main/packages/eliza-plugin)

### What it does

ElizaOS plugin for [KnowMint](https://knowmint.shop) — a marketplace where AI agents can discover and purchase human tacit knowledge (experience-based insights that AI can't generate on its own).

### Actions
- `SEARCH_KNOWLEDGE` — Search the marketplace
- `PURCHASE_KNOWLEDGE` — Record a purchase after on-chain payment (Solana)
- `GET_CONTENT` — Retrieve purchased content (x402 autonomous payment flow supported)

### Provider
- `trending-knowledge` — Injects top 5 trending knowledge items into agent context

### Notes
- Only `index.json` is modified
- Package is published and available on npm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for the Knowmint Eliza plugin package to the registry, making the plugin publicly discoverable and installable.
  * Registry entry added alongside existing Eliza-related packages to ensure consistent ordering and availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `@knowmint/eliza-plugin` to the registry, which provides ElizaOS integration with the KnowMint marketplace for AI agents to discover and purchase human tacit knowledge.

**Key changes:**
- Added single entry to `index.json` following alphabetical ordering
- Entry format follows registry conventions
- Plugin provides actions for knowledge search, purchase (Solana), and content retrieval with x402 payment support
- Includes a provider for trending knowledge context injection

**Issue identified:**
- The GitHub reference may need to specify the subdirectory path (`packages/eliza-plugin`) as indicated in the PR description, similar to the `@kamiyo/eliza` entry pattern

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor verification needed on subdirectory path
- The PR correctly modifies only `index.json` and follows alphabetical ordering conventions. However, the GitHub reference may need the subdirectory path specification (`packages/eliza-plugin`) based on the PR description. This is a common pattern for monorepo plugins as seen with `@kamiyo/eliza`. The change is minimal and low-risk, but verification of the correct path format is recommended before merging.
- Verify that the GitHub reference for `@knowmint/eliza-plugin` correctly resolves to the plugin code

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| index.json | Added `@knowmint/eliza-plugin` entry for KnowMint marketplace integration; entry may need subdirectory specification |

</details>



<sub>Last reviewed commit: c176145</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->