### PR TITLE
Add @newsriver/eliza-plugin

### DIFF
--- a/index.json
+++ b/index.json
@@ -228,6 +228,7 @@
    "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
    "@mascotai/plugin-connections": "github:mascotai/plugin-connections",
    "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
+   "@newsriver/eliza-plugin": "npm:@newsriver/eliza-plugin",
    "@nuggetslife/plugin-nuggets": "github:NuggetsLtd/eliza-plugin-nuggets",
    "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai",
    "@proofgate/eliza-plugin": "github:ProofGate/proofgate-eliza-plugin",


### PR DESCRIPTION
Adding the NewsRiver Global Intelligence API plugin. This provides a daily 'News Subscription' for agents via the x402 protocol and API keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated configuration to add a new public mapping entry, extending package availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single registry entry for `@newsriver/eliza-plugin`, a NewsRiver Global Intelligence API plugin. The change introduces two issues that must be resolved before merging:

1. **Format violation**: The entry value `"npm:@newsriver/eliza-plugin"` uses an unsupported URI scheme. The registry specification requires GitHub repository references in the form `github:organization/repository`, which is followed consistently by all ~240 other entries. The `npm:` prefix is incompatible with the automated `generated-registry.json` pipeline, which expects GitHub URIs to fetch version, branch, and compatibility metadata.

2. **Missing trailing newline**: The PR removes the newline at the end of `index.json`, violating POSIX text file conventions.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — the entry uses an unsupported `npm:` URI format that violates the registry specification and may break the automated metadata generation pipeline.
- The PR adds a single entry to the registry, but the value uses `npm:@newsriver/eliza-plugin` instead of the required `github:org/repo` format documented in the registry spec and followed by all 240+ other entries. This format violation will likely cause the automated `generated-registry.json` generation process to fail or produce incomplete metadata, since that pipeline expects GitHub URIs to fetch version, branch, and compatibility details. Additionally, the PR removes the trailing newline at end of file, which violates POSIX text file conventions. Both issues are straightforward to fix but must be resolved before merging.
- index.json — update the entry value to a valid `github:` URI format and restore the trailing newline.

<sub>Last reviewed commit: d0a31ad</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->