### PR TITLE
Add plugin-mycelia-signal — sovereign price oracle with L402/x402 payment

### DIFF
--- a/index.json
+++ b/index.json
@@ -240,5 +240,6 @@
    "plugin-connections": "github:mascotai/plugin-connections",
    "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
    "plugin-octav": "github:wpoulin/plugin-octav",
-   "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402"
+   "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402",
+   "@jonathanbulkeley/plugin-mycelia-signal": "github:jonathanbulkeley/elizaos-plugin-mycelia-signal"
 }

--- a/index.json
+++ b/index.json
@@ -224,6 +224,7 @@
    "@elizaos/plugin-zytron": "github:zypher-network/plugin-zytron",
    "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
    "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
+   "@jonathanbulkeley/plugin-mycelia-signal": "github:jonathanbulkeley/elizaos-plugin-mycelia-signal",
    "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
    "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
    "@mascotai/plugin-connections": "github:mascotai/plugin-connections",
@@ -240,6 +241,5 @@
    "plugin-connections": "github:mascotai/plugin-connections",
    "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
    "plugin-octav": "github:wpoulin/plugin-octav",
-   "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402",
-   "@jonathanbulkeley/plugin-mycelia-signal": "github:jonathanbulkeley/elizaos-plugin-mycelia-signal"
+   "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402"
 }


### PR DESCRIPTION
Adds Mycelia Signal sovereign price oracle plugin.

- Cryptographically signed price attestations for BTC, ETH, SOL, XAU, EUR pairs
- Pay per query via Lightning (L402) or USDC on Base (x402)
- No API keys, no subscriptions, no vendor trust required
- Every response independently verifiable against a known public key
- Supports Coinbase AgentKit x402 payment flow

npm: https://www.npmjs.com/package/@jonathanbulkeley/plugin-mycelia-signal
docs: https://myceliasignal.com/docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new plugin mapping to enable the mycelia-signal integration, making the plugin available for use in supported workflows. This update exposes the integration in the public plugin index and ensures it can be discovered and installed by users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers a new third-party plugin, `@jonathanbulkeley/plugin-mycelia-signal`, in the ElizaOS plugin registry (`index.json`). The plugin is described as a sovereign price oracle delivering cryptographically signed price attestations (BTC, ETH, SOL, XAU, EUR) with pay-per-query monetisation via Lightning (L402) or USDC on Base (x402).

Key observations:
- The entry follows the correct `"@scope/package-name": "github:owner/repo"` format used by other scoped packages.
- The new entry is appended at the bottom of the file, breaking the alphabetical ordering convention maintained by every other entry; it should be inserted between `@esscrypt/plugin-polkadot` and `@kamiyo/eliza`.
- No duplicate entry for this plugin or author already exists in the registry.
- The GitHub repository (`github:jonathanbulkeley/elizaos-plugin-mycelia-signal`) and the npm package name (`@jonathanbulkeley/plugin-mycelia-signal`) are consistent with each other.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after fixing the alphabetical ordering of the new entry.
- The change is a single-line addition to a registry JSON file with the correct key/value format. The only issue is that the entry is placed outside the established alphabetical sort order, which is a minor style concern and does not affect functionality.
- No files require special attention beyond correcting the sort position in `index.json`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `@jonathanbulkeley/plugin-mycelia-signal` entry, but the new entry is appended at the end of the file rather than inserted in its correct alphabetical position among the other `@`-scoped entries. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ElizaOS Registry (index.json)"] --> B["Plugin lookup by name"]
    B --> C{"Entry found?"}
    C -- "Yes" --> D["Resolve github:jonathanbulkeley/elizaos-plugin-mycelia-signal"]
    C -- "No" --> E["Plugin not found error"]
    D --> F["Install @jonathanbulkeley/plugin-mycelia-signal"]
    F --> G["Price Oracle Actions\n(BTC, ETH, SOL, XAU, EUR)"]
    G --> H{"Payment method"}
    H -- "Lightning" --> I["L402 pay-per-query"]
    H -- "USDC on Base" --> J["x402 / AgentKit flow"]
    I --> K["Signed price attestation returned"]
    J --> K
```

<sub>Last reviewed commit: 6cd205d</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->