### PR TITLE
feat: add elizaos-plugin-agentwallet — non-custodial wallet for ElizaOS agents

### DIFF
--- a/index.json
+++ b/index.json
@@ -237,7 +237,7 @@
    "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
    "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
    "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
-   "elizaos-plugin-agentwallet": "github:up2itnow0822/elizaos-plugin-agentwallet",
+   "@up2itnow0822/plugin-agentwallet": "github:up2itnow0822/elizaos-plugin-agentwallet#v1.0.0",
    "plugin-connections": "github:mascotai/plugin-connections",
    "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
    "plugin-octav": "github:wpoulin/plugin-octav",


### PR DESCRIPTION
## Plugin: elizaos-plugin-agentwallet

**npm:** https://www.npmjs.com/package/elizaos-plugin-agentwallet
**GitHub:** https://github.com/up2itnow0822/elizaos-plugin-agentwallet
**Version:** 1.0.0

### What it does
Non-custodial wallet plugin for ElizaOS agents. The agent holds its own private key — no custodial proxy, no vendor API dependency.

### Features
- EVM (Base, Ethereum, Arbitrum, Polygon) + Solana support
- x402 payments — auto-pay for HTTP 402 resources
- CCTP cross-chain USDC bridge (Circle)
- Uniswap V3 + Jupiter swaps
- Spend limits (per-tx and daily USD caps)

### Why it matters
Most agent wallet setups proxy through a vendor (Coinbase CDP, Privy, etc). This plugin eliminates the custody layer entirely — the agent signs every transaction locally with its own key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated a new Agent Wallet plugin to expand platform capabilities, enabling additional wallet/agent functionality and third-party extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers a new community wallet plugin, `elizaos-plugin-agentwallet`, to the ElizaOS registry. The plugin provides non-custodial EVM + Solana wallet capabilities (x402 payments, CCTP bridge, Uniswap V3 / Jupiter swaps, spend limits) for ElizaOS agents. The change is a single-line addition to `index.json` at line 240.

Two concerns warrant discussion before merging:

1. **Naming convention inconsistency**: The unscoped npm package name `elizaos-plugin-agentwallet` embeds the `elizaos` brand, whereas all other unscoped community plugins in this registry use neutral names (`plugin-*` without brand). Official ElizaOS plugins are published under the `@elizaos/` scope. The current naming could create brand confusion with users.

2. **Unpinned dependency for a financial plugin**: The registry entry points to the default branch without a commit SHA or release tag. For a plugin handling private keys and signing autonomous financial transactions, version pinning to a release tag (e.g. `#v1.0.0` as stated in the PR description) is a supply-chain security best practice.

<h3>Confidence Score: 3/5</h3>

- Mergeable with discussion — the two identified concerns (brand-confusing package name and unpinned dependency) are valid but not structural blockers. The naming inconsistency and lack of version pinning should be addressed before merge, especially given the financial/security-sensitive nature of the plugin.
- The PR adds a single registry entry that is syntactically correct and alphabetically ordered. However, two substantive concerns are present: (1) the unscoped package name `elizaos-plugin-agentwallet` breaks registry naming conventions by embedding the `elizaos` brand (all other unscoped entries use neutral names), creating potential user confusion; (2) the entry points to the default branch without version pinning, which is a supply-chain risk for a wallet plugin handling private keys and signing autonomous financial transactions. Both issues are addressable through straightforward changes (package rename and tag pin), so the PR is not blocked, but requires author engagement before merge.
- index.json (line 240) — address naming convention inconsistency and add version/commit pin for supply-chain security on a financial plugin.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ElizaOS Registry (index.json)"] -->|resolves| B["github:up2itnow0822/elizaos-plugin-agentwallet (default branch)"]
    B --> C["Plugin Loaded by ElizaOS Agent"]
    C --> D["EVM Wallets<br/>(Base, Ethereum, Arbitrum, Polygon)"]
    C --> E["Solana Wallet"]
    C --> F["x402 Auto-pay (HTTP 402)"]
    C --> G["CCTP USDC Bridge (Circle)"]
    C --> H["Uniswap V3 / Jupiter Swaps"]
    C --> I["Spend Limits<br/>(per-tx & daily USD caps)"]
    D --> J["Agent Private Key<br/>(held locally — non-custodial)"]
    E --> J
    style J fill:#f96,stroke:#c00,color:#000
```

<sub>Last reviewed commit: 70efadb</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->