### PR TITLE
Add @elizaos/plugin-agentwallet — non-custodial agent wallet with x402 payments

### DIFF
--- a/index.json
+++ b/index.json
@@ -33,6 +33,7 @@
    "@elizaos/plugin-abstract": "github:elizaos-plugins/plugin-abstract",
    "@elizaos/plugin-action-bench": "github:elizaos-plugins/plugin-action-bench",
    "@elizaos/plugin-agent-factory": "github:elizaos-plugins/plugin-agent-factory",
+   "@elizaos/plugin-agentwallet": "github:agentnexus/agent-wallet-sdk",
    "@elizaos/plugin-akash": "github:elizaos-plugins/plugin-akash",
    "@elizaos/plugin-allora": "github:elizaos-plugins/plugin-allora",
    "@elizaos/plugin-analytics": "github:elizaos-plugins/plugin-analytics",

--- a/index.json
+++ b/index.json
@@ -33,7 +33,7 @@
    "@elizaos/plugin-abstract": "github:elizaos-plugins/plugin-abstract",
    "@elizaos/plugin-action-bench": "github:elizaos-plugins/plugin-action-bench",
    "@elizaos/plugin-agent-factory": "github:elizaos-plugins/plugin-agent-factory",
-   "@elizaos/plugin-agentwallet": "github:agentnexus/agent-wallet-sdk",
+   "@elizaos/plugin-agentwallet": "github:up2itnow0822/agent-wallet-sdk",
    "@elizaos/plugin-akash": "github:elizaos-plugins/plugin-akash",
    "@elizaos/plugin-allora": "github:elizaos-plugins/plugin-allora",
    "@elizaos/plugin-analytics": "github:elizaos-plugins/plugin-analytics",


### PR DESCRIPTION
## Plugin Submission: @elizaos/plugin-agentwallet

**Plugin name:** @elizaos/plugin-agentwallet
**npm package:** agentwallet-sdk (v3.4.2)
**GitHub:** https://github.com/agentnexus/agent-wallet-sdk
**Author:** AgentNexus / up2itnow0822

### Description

Non-custodial TypeScript SDK for AI agent wallets — x402 payments, CCTP V2 cross-chain transfers, ERC-6551 token-bound accounts, and on-chain spend limits.

Your ElizaOS agent holds its own private key. No custodian. No KYC. No freeze risk.

### What it does

- Gives ElizaOS agents an autonomous wallet with hard on-chain spend limits
- x402 native: agent can pay APIs automatically via HTTP 402 payment flow
- CCTP V2 cross-chain: USDC bridging across Base, Ethereum, Arbitrum, Polygon, Etherlink
- On-chain enforced limits — not API policies, actual EVM contract enforcement

### Integration

```bash
npm i agentwallet-sdk
```

```json
{
  "plugins": ["@elizaos/plugin-agentwallet"],
  "settings": {
    "AGENT_PRIVATE_KEY": "0x...",
    "AGENT_ACCOUNT_ADDRESS": "0x...",
    "AGENT_CHAIN": "base"
  }
}
```

### Compatibility

- AP2 ✅
- x402 ✅
- MCP ✅
- Etherlink ✅
- CCTP V2 ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new wallet plugin integration.

* **Chores**
  * Minor repository metadata formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers `@elizaos/plugin-agentwallet` in the plugin registry, pointing to `github:agentnexus/agent-wallet-sdk` — a non-custodial agent wallet SDK supporting x402 payments, CCTP V2 cross-chain transfers, and ERC-6551 token-bound accounts.

Key concerns with the submission:

- **SDK vs. ElizaOS plugin repository**: The registry value `github:agentnexus/agent-wallet-sdk` references a repository named `agent-wallet-sdk`, which is described as a TypeScript SDK. The registry is intended to point to repositories that export a valid ElizaOS `Plugin` object (conforming to the ElizaOS plugin interface). If this repository is the raw SDK and not an ElizaOS plugin wrapper, the entry will fail to load at runtime. The PR description acknowledges the npm package is `agentwallet-sdk` — it is unclear whether the referenced GitHub repo also exposes a proper ElizaOS plugin entrypoint.
- **Missing trailing newline**: The PR incidentally removes the newline at the end of `index.json`, breaking POSIX text-file conventions and potentially causing issues with diff tooling and editors.

<h3>Confidence Score: 2/5</h3>

- This PR should not be merged until it is confirmed that the referenced GitHub repository exports a valid ElizaOS plugin interface, not just an SDK.
- The registry entry points to a repository called `agent-wallet-sdk` which is described as an SDK. Without confirmation that this repo exports an ElizaOS-compatible `Plugin` object, the entry is likely broken for ElizaOS users. Additionally, the trailing newline was inadvertently removed from the file.
- index.json — the new registry entry at line 36 needs verification that `github:agentnexus/agent-wallet-sdk` is a proper ElizaOS plugin wrapper.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `@elizaos/plugin-agentwallet` pointing to `github:agentnexus/agent-wallet-sdk`; the target repo appears to be an SDK rather than a dedicated ElizaOS plugin wrapper, and the PR also removes the trailing newline from the file. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ElizaOS Runtime] -->|loads plugin| B["@elizaos/plugin-agentwallet"]
    B -->|resolves via registry| C["github:agentnexus/agent-wallet-sdk"]
    C -->|Expected: Plugin object| D["ElizaOS Plugin Interface\n(actions, providers, evaluators)"]
    C -->|Actual risk: SDK only| E["Raw SDK\n(no ElizaOS plugin export)"]
    D -->|success| F[Agent Wallet Functionality\nx402 payments / CCTP V2 / ERC-6551]
    E -->|failure| G[Runtime load error]
```

<sub>Last reviewed commit: 6d8c919</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->