### PR TITLE
Add @chainward/elizaos-plugin

### DIFF
--- a/index.json
+++ b/index.json
@@ -4,7 +4,7 @@
    "@asterpay/plugin-payments": "github:AsterPay/plugin-payments",
    "@bealers/plugin-mattermost": "github:bealers/plugin-mattermost",
    "@blockrun/elizaos-plugin": "github:BlockRunAI/elizaos-plugin-blockrun",
-   "@chainward/elizaos-plugin": "github:saltxd/chainward",
+   "@chainward/elizaos-plugin": "github:saltxd/chainward#main:packages/elizaos-plugin",
    "@coinrailz/plugin-coinrailz": "github:tdnupe3/coinrailz-eliza-plugin",
    "@elizaos/adapter-mongodb": "github:elizaos-plugins/adapter-mongodb",
    "@elizaos/adapter-pglite": "github:elizaos-plugins/adapter-pglite",


### PR DESCRIPTION
## Summary

Adds [@chainward/elizaos-plugin](https://www.npmjs.com/package/@chainward/elizaos-plugin) to the registry.

**ChainWard** — real-time monitoring, smart alerts, and gas analytics for autonomous AI agent wallets on Base.

### Plugin features
- Auto-registers agent wallet on startup
- 6 actions: register agent, list agents, list transactions, check balance, create/list alerts
- Uses `@chainward/sdk` for all API calls
- Auth via `ag_` API key passed in plugin config

### Links
- **npm:** https://www.npmjs.com/package/@chainward/elizaos-plugin
- **SDK:** https://www.npmjs.com/package/@chainward/sdk
- **Source:** https://github.com/saltxd/agentguard/tree/main/packages/elizaos-plugin
- **Website:** https://chainward.ai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new top-level plugin reference to the project configuration to register an external plugin source. This is a single-line configuration addition that registers the plugin location but does not alter existing functionality or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `@chainward/elizaos-plugin` — a real-time wallet monitoring and alerts plugin for AI agents on Base — to the ElizaOS plugin registry. The change is a single-line addition to `index.json`.

**Issue found:**
- **Incorrect GitHub reference:** The registry entry resolves to `github:saltxd/agentguard`, which is the root of a monorepo. The actual plugin lives at `packages/elizaos-plugin` inside that repo (confirmed by the PR description and npm package page). Without specifying the subdirectory using the `#branch:path` syntax (e.g. `github:saltxd/agentguard#main:packages/elizaos-plugin`), registry consumers will point to a directory that does not have the correct `package.json` for this plugin. The existing entry for `@kamiyo/eliza` (line 228) demonstrates the correct pattern for monorepo subdirectories.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — the GitHub reference points to the monorepo root rather than the plugin subdirectory, which would cause installation failures for users.
- The single change is a registry entry, but it contains a functional error. The GitHub reference resolves to the root of the `saltxd/agentguard` monorepo rather than the `packages/elizaos-plugin` subdirectory where the actual plugin source code lives. This would cause any consumer trying to install `@chainward/elizaos-plugin` via this registry to fail. The fix is straightforward (add `#main:packages/elizaos-plugin` to the reference), but the current entry should not be merged.
- index.json — line 7 requires the subdirectory path to be appended to the GitHub reference.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Registry Consumer\nreads index.json] --> B{Resolves entry\n'@chainward/elizaos-plugin'}
    B --> C["Current: github:saltxd/agentguard\n(repo root)"]
    B --> D["Expected: github:saltxd/agentguard#main:packages/elizaos-plugin\n(plugin subdirectory)"]
    C --> E["❌ No package.json at root\nfor @chainward/elizaos-plugin\nInstall fails"]
    D --> F["✅ Finds packages/elizaos-plugin/package.json\nInstall succeeds"]
```

<sub>Last reviewed commit: 9b92896</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->