### PR TITLE
Add @scoutscore/plugin-eliza

### DIFF
--- a/index.json
+++ b/index.json
@@ -232,6 +232,7 @@
    "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai",
    "@proofgate/eliza-plugin": "github:ProofGate/proofgate-eliza-plugin",
    "@pyboom/plugin-moralis-v2": "github:matteo-brandolino/plugin-moralis-v2",
+   "@scoutscore/plugin-eliza": "github:scoutscore/plugin-scoutscore",
    "@standujar/plugin-composio": "github:standujar/plugin-composio",
    "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
    "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",


### PR DESCRIPTION
## Add @scoutscore/plugin-eliza

Adds the ScoutScore trust intelligence plugin for ElizaOS.

**Package**: `@scoutscore/plugin-eliza`
**Repo**: https://github.com/scoutscore/plugin-scoutscore

### What it does

ScoutScore gives ElizaOS agents the ability to verify x402 services before making payments. The plugin provides:

- **5 actions**: CHECK_SERVICE_TRUST, CHECK_FIDELITY, SCAN_SKILL, BROWSE_LEADERBOARD, BATCH_SCORE_SERVICES
- **2 providers**: trust-context (auto-injects trust data), trust-policy (payment guidelines)
- **1 evaluator**: transaction-guard (blocks/warns on unsafe x402 payments)
- **Background service**: domain trust monitoring

It calls the [ScoutScore API](https://scoutscore.ai) to score x402 services across 4 trust pillars (Contract Clarity, Availability, Response Fidelity, Identity Safety).

### Checklist

- [x] Only `index.json` modified
- [x] Plugin repo is public: https://github.com/scoutscore/plugin-scoutscore
- [x] Has `elizaos-plugins` GitHub topic
- [x] Has logo (400x400) and banner (1280x640) images
- [x] Plugin builds and exports default Plugin object
- [x] Custom description (not placeholder)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Eliza plugin, expanding available plugin options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single entry to the plugin registry, mapping the `@scoutscore/plugin-eliza` npm package to the `github:scoutscore/plugin-scoutscore` repository. The change is minimal, correctly formatted, and alphabetically sorted within `index.json`.

**Key observations:**
- The registry entry follows the correct `"npm-package-name": "github:org/repo"` format with no `.git` extension and using `github:` (not `github.com`).
- The alphabetical placement is correct — `@scoutscore` falls between `@pyboom` and `@standujar`.
- The npm package name (`@scoutscore/plugin-eliza`) differs from the GitHub repository name (`plugin-scoutscore`). This is permitted by the registry format, but the `name` field inside the repo's `package.json` **must** be `@scoutscore/plugin-eliza` for the elizaOS plugin loader to resolve it correctly during installation.

<h3>Confidence Score: 3/5</h3>

- The change is syntactically valid and properly formatted, but requires confirmation that the referenced repository's package.json declares the correct npm package name to avoid runtime plugin loader failures.
- The registry entry itself is correct in format and placement, earning it a baseline score. However, a critical unresolved dependency remains: the external repository's `package.json` must declare `"name": "@scoutscore/plugin-eliza"` for the elizaOS plugin loader to resolve the package correctly. Without author confirmation of this prerequisite, merging carries the risk that the plugin will fail to install or load despite the registry entry being correct.
- index.json (line 235) — requires author confirmation that the referenced GitHub repo's package.json contains the correct npm package name.

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ElizaOS CLI
    participant Registry (index.json)
    participant GitHub (scoutscore/plugin-scoutscore)

    User->>ElizaOS CLI: elizaos install @scoutscore/plugin-eliza
    ElizaOS CLI->>Registry (index.json): lookup "@scoutscore/plugin-eliza"
    Registry (index.json)-->>ElizaOS CLI: "github:scoutscore/plugin-scoutscore"
    ElizaOS CLI->>GitHub (scoutscore/plugin-scoutscore): fetch package
    GitHub (scoutscore/plugin-scoutscore)-->>ElizaOS CLI: plugin source
    Note over ElizaOS CLI: Validates package.json "name" == "@scoutscore/plugin-eliza"
    ElizaOS CLI-->>User: Plugin installed & registered
```

<sub>Last reviewed commit: 543c8c0</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->