### PR TITLE
Add picoads - AI Agent Ad Marketplace

### DIFF
--- a/index.json
+++ b/index.json
@@ -230,6 +230,7 @@
    "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
    "@nuggetslife/plugin-nuggets": "github:NuggetsLtd/eliza-plugin-nuggets",
    "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai",
+   "@picoads/eliza-plugin": "github:picoads/eliza-plugin",
    "@proofgate/eliza-plugin": "github:ProofGate/proofgate-eliza-plugin",
    "@pyboom/plugin-moralis-v2": "github:matteo-brandolino/plugin-moralis-v2",
    "@standujar/plugin-composio": "github:standujar/plugin-composio",


### PR DESCRIPTION
# Registry Update Checklist

Registry:
- [ ✅ ] I've made the left side of the colon of JSON entry in index.json match the potential NPM package name
- [ ✅ ] I've used github not github.com
- [ ✅ ] There is no .git extension
- [ ✅ ] It's placed it alphabetically in the list
- [ ✅ ] I've dealt with commas properly so the list is still valid JSON

If not an eliza-plugins official repo, i.e. new plugin: 

The plugin repo has:
- [ ✅ ] is publically accessible (not a private repo)
- [ ✅ ] uses main as it's default branch
- [ ✅ ] I have include `elizaos-plugins` in the topics in the GitHub repo settings. If the plugin is related to `AI` or `crypto`, please add those as topics as well.
- [ ✅ ] add simple description in github repo
- [ ✅ ] follows this convention
```
plugin-name/
├── images/
│   ├── logo.jpg        # Plugin branding logo
│   ├── banner.jpg      # Plugin banner image
├── src/
│   ├── index.ts        # Main plugin entry point
│   ├── actions/        # Plugin-specific actions
│   ├── clients/        # Client implementations
│   ├── adapters/       # Adapter implementations
│   └── types.ts        # Type definitions
│   └── environment.ts  # runtime.getSetting, zod validation
├── package.json        # Plugin dependencies
└── README.md          # Plugin documentation
```
- [ ✅ ] an `images/banner.jpg` and `images/logo.jpg` and they
  - Use clear, high-resolution images
  - Keep file sizes optimized (< 500KB for logos, < 1MB for banners)
  - Follow the [elizaOS Brand Guidelines](https://github.com/elizaOS/brandkit)
  - Include alt text for accessibility
- [ ✅ ] package.json has a agentConfig like the following
```json
{
  "name": "@myNpmOrg/plugin-example",
  "version": "1.0.0",
  "agentConfig": {
    "pluginType": "elizaos:plugin:1.0.0",
    "pluginParameters": {
      "API_KEY": {
        "type": "string",
        "description": "API key for the service"
      }
    }
  }
}
```

<!-- If you are on Discord, please join https://discord.gg/elizaOS and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the Eliza plugin, expanding available integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers a new plugin entry `@picoads/eliza-plugin` (pointing to `github:picoads/eliza-plugin`) in the ElizaOS plugin registry. The change is a single-line addition to `index.json`.

**Checklist observations:**
- JSON syntax is valid and commas are correctly placed.
- The entry is correctly alphabetised between `@onbonsai/plugin-bonsai` and `@proofgate/eliza-plugin` ("`pi`" sorts between "`on`" and "`pr`").
- The `github:` scheme is used (not `github.com:`), and there is no `.git` suffix.
- The package name key (`@picoads/eliza-plugin`) matches what would be the NPM package name.

**Minor concern:**
- Both the NPM package name and the GitHub repo use the generic suffix `eliza-plugin` rather than a descriptive plugin name (e.g. `plugin-picoads` or `plugin-picoads-ads`). While there is a precedent in the registry (e.g. `@proofgate/eliza-plugin`), adopting a more descriptive name would better align with the dominant `plugin-<functionality>` naming convention used throughout the registry. This is not a blocker but worth noting.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it adds a single well-formed registry entry with no structural issues.
- The change is minimal (one line in index.json), JSON syntax is valid, ordering is correct, and formatting conventions are followed. A point is deducted because the plugin and repo both use the generic name `eliza-plugin` rather than a descriptive plugin name, which is a minor convention deviation worth reviewing before merging.
- No files require special attention beyond the minor naming convention note in `index.json`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `@picoads/eliza-plugin` registry entry pointing to `github:picoads/eliza-plugin`. JSON is well-formed, alphabetical ordering is correct, and the `github:` scheme is used without a `.git` extension. Minor concern: the repo/package name `eliza-plugin` is generic and doesn't describe the plugin's functionality. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Registry as elizaos-plugins/registry (index.json)
    participant NPM as @picoads/eliza-plugin (NPM)
    participant GH as github:picoads/eliza-plugin

    Dev->>Registry: Add entry "@picoads/eliza-plugin"
    Registry-->>NPM: Resolves package name
    Registry-->>GH: Points to GitHub source
    NPM->>GH: Install / resolve source
```

<sub>Last reviewed commit: fbab0f6</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->