### PR TITLE
feat: add elizaos-plugin-omnifun

### DIFF
--- a/index.json
+++ b/index.json
@@ -237,6 +237,7 @@
    "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
    "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
    "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
+   "elizaos-plugin-omnifun": "github:0xzcov/elizaos-plugin-omnifun",
    "plugin-connections": "github:mascotai/plugin-connections",
    "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
    "plugin-octav": "github:wpoulin/plugin-octav",


### PR DESCRIPTION
## Summary

Adds `elizaos-plugin-omnifun` — multichain memecoin launchpad plugin for ElizaOS.

- **npm**: [elizaos-plugin-omnifun](https://www.npmjs.com/package/elizaos-plugin-omnifun)
- **GitHub**: [0xzcov/elizaos-plugin-omnifun](https://github.com/0xzcov/elizaos-plugin-omnifun)

Tokenize your AI agent as an oMeme and earn passive USDC forever across EVM and non-EVM chains simultaneously — from a single LP. 0.5% creator fee + 50% Uniswap V3 LP fees after graduation. 8 chains, 5-25s settlement.

**8 actions:** register, trade, launch, portfolio, feed, quote, rewards, strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New elizaos-plugin-omnifun plugin is now available for integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `elizaos-plugin-omnifun` to the plugin registry — a multichain memecoin launchpad plugin for ElizaOS by `0xzcov`.

- The change is a single-line addition to `index.json`, which is the expected format for registry submissions
- The entry is correctly alphabetically sorted among unscoped packages (after all `@`-scoped packages)
- JSON formatting is valid with proper comma placement
- The npm package name (`elizaos-plugin-omnifun`) matches the GitHub repo name convention

<h3>Confidence Score: 4/5</h3>

- This PR is a minimal, low-risk registry entry addition that follows established conventions.
- Single-line addition to the plugin registry index. The JSON is valid, alphabetical ordering is correct, and the entry follows the same format as existing entries. No code logic changes involved — this is purely a data/configuration change.
- No files require special attention. The only change is a single line in `index.json`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds a single new registry entry for `elizaos-plugin-omnifun` pointing to `github:0xzcov/elizaos-plugin-omnifun`. The entry is correctly placed in alphabetical order, uses valid JSON formatting, and follows the existing `"package-name": "github:org/repo"` convention. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: Add elizaos-plugin-omnifun] --> B[index.json updated]
    B --> C[GitHub Action triggered on merge]
    C --> D[Process plugin entry]
    D --> E[Fetch metadata from github:0xzcov/elizaos-plugin-omnifun]
    E --> F[Update generated-registry.json]
    F --> G[Plugin available in elizaOS CLI & web registry]
```

<sub>Last reviewed commit: 425cb5d</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->