### PR TITLE
Add buff-elizaos-plugin — round-up investing for agents

### DIFF
--- a/index.json
+++ b/index.json
@@ -237,6 +237,7 @@
    "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
    "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
    "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
+   "buff-elizaos-plugin": "github:alexiskarstensen/Sow",
    "plugin-connections": "github:mascotai/plugin-connections",
    "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
    "plugin-octav": "github:wpoulin/plugin-octav",


### PR DESCRIPTION
## Add Buff Round-Up Investing Plugin

**npm**: [`buff-elizaos-plugin`](https://www.npmjs.com/package/buff-elizaos-plugin)  
**GitHub**: [alexiskarstensen/Sow/packages/elizaos-plugin](https://github.com/alexiskarstensen/Sow/tree/master/packages/elizaos-plugin)

### What it does
Auto-invests spare change from every agent transaction into crypto assets (BTC, ETH, SOL, USDC) via Jupiter on Solana. Like Acorns, but for AI agents.

### Actions
| Action | Description |
|--------|-------------|
| `BUFF_ROUNDUP` | Record a round-up from any transaction |
| `BUFF_INVEST` | Check threshold & auto-swap via Jupiter |
| `BUFF_PORTFOLIO` | View invested assets & balances |
| `BUFF_SET_PLAN` | Change round-up tier (seed/sprout/tree/forest) |
| `BUFF_SET_ALLOC` | Set portfolio allocation (e.g. 60% BTC, 40% ETH) |

### Provider
`buffPortfolioProvider` — auto-injects portfolio context into conversations

### Config
```
BUFF_AGENT_SEED=hex-seed
BUFF_PLAN=sprout
BUFF_INVEST_INTO=BTC
BUFF_THRESHOLD=5
```

### Links
- [Docs](https://sow-beryl.vercel.app/docs)
- [SKILL.md](https://sow-beryl.vercel.app/SKILL.md)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `buff-elizaos-plugin` to the plugin registry — a round-up investing plugin that auto-invests spare change from agent transactions into crypto assets via Jupiter on Solana.

- The new entry is correctly formatted as valid JSON and placed in the proper alphabetical position among non-scoped packages.
- **Issue**: The GitHub reference `github:alexiskarstensen/Sow` points to the root of a monorepo, but the plugin source lives at `packages/elizaos-plugin`. The registry generation script fetches `package.json` from the repo root, so version and `@elizaos/core` compatibility detection will not work correctly for this entry.

<h3>Confidence Score: 3/5</h3>

- Low risk change to a single JSON file, but the monorepo path issue will cause incorrect metadata generation.
- Score of 3 reflects that the change is minimal (one line in index.json) and won't break the existing registry, but the GitHub reference likely needs to include the subdirectory path to produce correct metadata in generated-registry.json.
- `index.json` — the GitHub reference for `buff-elizaos-plugin` should include the monorepo subdirectory path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `buff-elizaos-plugin` registry entry. JSON format and alphabetical ordering are correct. However, the GitHub reference points to a monorepo root rather than the plugin subdirectory, which will cause registry generation metadata issues. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR merges index.json] --> B[GitHub Action triggers]
    B --> C[generate-registry.js reads index.json]
    C --> D["parseGitRef('github:alexiskarstensen/Sow')"]
    D --> E["fetchPackageJSON(owner, repo, branch)"]
    E --> F{Fetches root package.json}
    F -->|Root is monorepo| G["Missing @elizaos/core dependency"]
    G --> H["supports: {v0: false, v1: false}"]
    F -->|Root is plugin| I["Detects @elizaos/core range"]
    I --> J[Correct version compatibility]
```

<sub>Last reviewed commit: d021cf8</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->