### PR TITLE
Add buff-elizaos-plugin — round-up investing for agents

### DIFF
--- a/index.json
+++ b/index.json
@@ -237,6 +237,7 @@
    "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
    "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
    "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
+   "buff-elizaos-plugin": "github:nightcode112/Buff",
    "plugin-connections": "github:mascotai/plugin-connections",
    "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
    "plugin-octav": "github:wpoulin/plugin-octav",


### PR DESCRIPTION
## Add Buff Round-Up Investing Plugin

**npm**: [`buff-elizaos-plugin`](https://www.npmjs.com/package/buff-elizaos-plugin)  
**GitHub**: [nightcode112/Buff/packages/elizaos-plugin](https://github.com/nightcode112/Buff/tree/master/packages/elizaos-plugin)

### What it does
Auto-invests spare change from every agent transaction into crypto assets (BTC, ETH, SOL, USDC) via Jupiter on Solana. Like Acorns, but for AI agents.

### Actions
| Action | Description |
|--------|-------------|
| `BUFF_ROUNDUP` | Record a round-up from any transaction |
| `BUFF_INVEST` | Check threshold & auto-swap via Jupiter |
| `BUFF_PORTFOLIO` | View invested assets & balances |
| `BUFF_SET_PLAN` | Change round-up tier (seed/sprout/tree/forest) |
| `BUFF_SET_ALLOC` | Set portfolio allocation (e.g. 60% BTC, 40% ETH) |

### Provider
`buffPortfolioProvider` — auto-injects portfolio context into conversations

### Config
```
BUFF_AGENT_SEED=hex-seed
BUFF_PLAN=sprout
BUFF_INVEST_INTO=BTC
BUFF_THRESHOLD=5
```

### Links
- [Docs](https://sow-beryl.vercel.app/docs)
- [SKILL.md](https://sow-beryl.vercel.app/SKILL.md)
- [GitHub](https://github.com/nightcode112/Buff)