### PR TITLE
Add buff-elizaos-plugin — round-up investing for agents

### DIFF
--- a/index.json
+++ b/index.json
@@ -237,6 +237,7 @@
    "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
    "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
    "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
+   "buff-elizaos-plugin": "github:nightcode112/Buff",
    "plugin-connections": "github:mascotai/plugin-connections",
    "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
    "plugin-octav": "github:wpoulin/plugin-octav",


### PR DESCRIPTION
## Add Buff Round-Up Investing Plugin

**npm**: [`buff-elizaos-plugin`](https://www.npmjs.com/package/buff-elizaos-plugin)  
**GitHub**: [nightcode112/Buff/packages/elizaos-plugin](https://github.com/nightcode112/Buff/tree/master/packages/elizaos-plugin)

### What it does
Auto-invests spare change from every agent transaction into crypto assets (BTC, ETH, SOL, USDC) via Jupiter on Solana. Like Acorns, but for AI agents.

### Actions
| Action | Description |
|--------|-------------|
| `BUFF_ROUNDUP` | Record a round-up from any transaction |
| `BUFF_INVEST` | Check threshold & auto-swap via Jupiter |
| `BUFF_PORTFOLIO` | View invested assets & balances |
| `BUFF_SET_PLAN` | Change round-up tier (seed/sprout/tree/forest) |
| `BUFF_SET_ALLOC` | Set portfolio allocation (e.g. 60% BTC, 40% ETH) |

### Provider
`buffPortfolioProvider` — auto-injects portfolio context into conversations

### Links
- [Docs](https://sow-beryl.vercel.app/docs)
- [SKILL.md](https://sow-beryl.vercel.app/SKILL.md)
- [GitHub](https://github.com/nightcode112/Buff)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `buff-elizaos-plugin` entry to `index.json`, registering a round-up investing plugin for ElizaOS agents. The entry is properly formatted and alphabetically sorted among the unscoped packages.

- The main concern is that the GitHub reference (`github:nightcode112/Buff`) points to a monorepo root, while the PR description indicates the actual plugin lives in `packages/elizaos-plugin`. The registry generation script (`generate-registry.js`) only reads `package.json` from the repo root, so this will produce `null` values for version detection, core compatibility, and branch analysis in the generated registry.
- The npm package `buff-elizaos-plugin` could not be verified to exist on the npm registry, which means npm-based version information will also be empty.
- The repository `nightcode112/Buff` could not be verified as publicly accessible.

<h3>Confidence Score: 2/5</h3>

- This PR will not break existing entries, but the new entry will not function correctly in the generated registry due to the monorepo structure issue.
- Score of 2 reflects that while the change is minimal (one line in index.json) and correctly formatted, the registry entry will produce broken/null output in generated-registry.json because the plugin's package.json is in a subdirectory rather than at the repo root. The npm package also could not be verified.
- index.json — the new `buff-elizaos-plugin` entry needs to reference a repository where package.json is at the root

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `buff-elizaos-plugin` entry pointing to `github:nightcode112/Buff`. The entry is correctly sorted alphabetically and uses valid JSON syntax, but the GitHub reference points to a monorepo root while the plugin source reportedly lives in a subdirectory (`packages/elizaos-plugin`), which will break the registry generation script's version detection. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["index.json entry:<br/>buff-elizaos-plugin → github:nightcode112/Buff"] --> B["generate-registry.js"]
    B --> C["parseGitRef()<br/>owner: nightcode112, repo: Buff"]
    C --> D["fetchPackageJSON()<br/>path: package.json (root)"]
    D --> E{"package.json at<br/>repo root?"}
    E -- "Yes" --> F["Extract version &<br/>@elizaos/core range"]
    E -- "No (monorepo)" --> G["Returns null ❌"]
    G --> H["generated-registry.json:<br/>all fields null,<br/>supports: v0=false, v1=false"]
    F --> I["Version detection &<br/>compatibility analysis"]
    I --> J["generated-registry.json:<br/>valid entry ✅"]
```

<sub>Last reviewed commit: eed8dde</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->