### PR TITLE
Add buff-elizaos-plugin — round-up investing for agents

### DIFF
--- a/index.json
+++ b/index.json
@@ -367,6 +367,7 @@
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
+  "buff-elizaos-plugin": "github:nightcode112/buff-elizaos-plugin",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",


### PR DESCRIPTION
## Add Buff Round-Up Investing Plugin

**npm**: [`buff-elizaos-plugin`](https://www.npmjs.com/package/buff-elizaos-plugin)  
**GitHub**: [nightcode112/buff-elizaos-plugin](https://github.com/nightcode112/buff-elizaos-plugin) (dedicated repo, package.json at root)

### What it does
Auto-invests spare change from every agent transaction into crypto assets (BTC, ETH, SOL, USDC) via Jupiter on Solana.

### Actions
| Action | Description |
|--------|-------------|
| `BUFF_ROUNDUP` | Record a round-up from any transaction |
| `BUFF_INVEST` | Check threshold & auto-swap via Jupiter |
| `BUFF_PORTFOLIO` | View invested assets & balances |
| `BUFF_SET_PLAN` | Change round-up tier (seed/sprout/tree/forest) |
| `BUFF_SET_ALLOC` | Set portfolio allocation (e.g. 60% BTC, 40% ETH) |

### Registry Update Checklist

- [x] NPM package name matches the registry key (`buff-elizaos-plugin`)
- [x] JSON is properly formatted
- [x] Entry is alphabetically sorted among unscoped packages
- [x] GitHub repo is publicly accessible
- [x] `package.json` is at the repo root (dedicated repo, not monorepo)
- [x] No duplicate entries or conflicting registrations
- [x] Only `index.json` is modified

### Note
This is a dedicated repo (not a monorepo subdirectory) — `package.json` is at the root for correct registry generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new plugin to the available plugins registry, expanding functionality options for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single registry entry for `buff-elizaos-plugin`, a round-up investing plugin for ElizaOS agents that auto-invests spare change into crypto assets via Jupiter on Solana. The diff is correctly scoped to one line in `index.json`, the entry is alphabetically ordered, and the format matches the rest of the registry. The npm package (`buff-elizaos-plugin`) and GitHub repo (`nightcode112/buff-elizaos-plugin`) both exist. A previous review comment about extraneous entries is no longer applicable to the current diff state.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single well-formed registry entry with a verified npm package and GitHub repo.

The PR adds exactly one line, correctly formatted, alphabetically sorted among unscoped packages, and the referenced package and repository exist. No prior-review concerns apply to the current diff.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| index.json | Adds one correctly formatted, alphabetically ordered registry entry for buff-elizaos-plugin pointing to github:nightcode112/buff-elizaos-plugin. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ElizaOS Agent Transaction] --> B[BUFF_ROUNDUP\nRecord spare change]
    B --> C{Accumulated ≥ threshold?}
    C -- No --> D[Wait for next transaction]
    C -- Yes --> E[BUFF_INVEST\nAuto-swap via Jupiter on Solana]
    E --> F[BUFF_PORTFOLIO\nView invested assets & balances]
    G[BUFF_SET_PLAN\nseed/sprout/tree/forest tier] --> C
    H[BUFF_SET_ALLOC\nBTC/ETH/SOL/USDC %] --> E
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `index.json`, line 617 ([link](https://github.com/elizaos-plugins/registry/blob/3e55f7b9d86f55d03baca8791f40174704a6d4ec/index.json#L617)) 

   **PR scope far exceeds a single-entry addition**

   This diff does not just add `buff-elizaos-plugin`. Compared to the current `main` base commit (`ef4930f`), it also re-indents the entire file from 3 spaces to 2 spaces **and** introduces roughly 130 additional registry entries (e.g. `@andysalvo/plugin-x402-trust`, `@elisym/plugin-elizaos-elisym`, `@elizaos/cache-redis`, `@elizaos/client-alexa`, and many more) that were never reviewed in this PR.

   If merged as-is, those unreviewed entries would bypass the normal per-PR review process. The author's branch appears to have been forked from — or manually merged with — a version of the registry that is ahead of the current `main`. The PR should be rebased on the current `main` tip and reduced to the single `buff-elizaos-plugin` line.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Add buff-elizaos-plugin — round-up inves..."](https://github.com/elizaos-plugins/registry/commit/669c8cc7b71744515bcd17f224a6bff5dc39db1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25363443)</sub>

<!-- /greptile_comment -->