### PR TITLE
feat: add @guanxing1/plugin-elizaos — Chinese metaphysics AI plugin

### DIFF
--- a/index.json
+++ b/index.json
@@ -224,6 +224,7 @@
    "@elizaos/plugin-zytron": "github:zypher-network/plugin-zytron",
    "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
    "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
+   "@guanxing1/plugin-elizaos": "github:doggychip/plugin-guanxing",
    "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
    "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
    "@mascotai/plugin-connections": "github:mascotai/plugin-connections",


### PR DESCRIPTION
## Plugin: @guanxing1/plugin-elizaos (GuanXing 观星)

### Overview
GuanXing (观星) is a Chinese metaphysics AI plugin that brings traditional Eastern wisdom to ElizaOS agents. 10 actions covering BaZi (八字), Feng Shui, Tarot, I-Ching, fortune telling, dream interpretation, and more.

### Plugin Info
- **npm**: [@guanxing1/plugin-elizaos](https://www.npmjs.com/package/@guanxing1/plugin-elizaos)
- **GitHub**: [doggychip/plugin-guanxing](https://github.com/doggychip/plugin-guanxing)
- **Demo**: [heartai.zeabur.app](https://heartai.zeabur.app)

### Actions (10)
| Action | Description |
|--------|-------------|
| BAZI_ANALYSIS | 八字 birth chart analysis |
| DAILY_FORTUNE | Personalized daily fortune |
| QIUQIAN | Temple-style divination (求签) |
| TAROT_READING | Tarot with Eastern interpretation |
| DREAM_INTERPRETATION | Dream analysis (解梦) |
| ALMANAC_LOOKUP | Chinese almanac |
| FENGSHUI_ANALYSIS | Feng Shui analysis |
| NAME_SCORE | Name scoring (姓名打分) |
| COMPATIBILITY_CHECK | Compatibility via 八字合盘 |
| ZODIAC_FORTUNE | Chinese zodiac (生肖运势) |

### Demo Evidence
- Live: https://heartai.zeabur.app
- Also on ClawHub: `clawhub install guanxing`
- MCP server: `@guanxing1/mcp-server` on npm

### Quality Checklist
- [x] Standard plugin structure (src/, dist/, images/)
- [x] Branding assets (logo.jpg 400x400, banner.jpg 1280x640)
- [x] README complete
- [x] agentConfig in package.json
- [x] Published on npm
- [x] TypeScript, builds clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New plugin now available for extending application functionality and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers the `@guanxing1/plugin-elizaos` (GuanXing 观星) Chinese metaphysics AI plugin into the elizaOS plugin registry by adding a single mapping line to `index.json`. The plugin covers 10 actions including BaZi analysis, Feng Shui, Tarot, I-Ching, dream interpretation, and more.

**Changes:**
- Adds `"@guanxing1/plugin-elizaos": "github:doggychip/plugin-guanxing"` to `index.json`
- Entry is correctly alphabetically sorted between `@esscrypt/plugin-polkadot` and `@kamiyo/eliza`
- JSON syntax, `github:` prefix (not `github.com`), and absence of a `.git` extension are all correct

**Observations:**
- The npm package scope (`@guanxing1`) and the GitHub repository owner (`doggychip`) are different identities. While not prohibited by the registry format, this inconsistency makes ownership verification harder and differs from the pattern used by virtually all other third-party entries in the file. The PR description does not explain or reconcile this discrepancy.
- The PR description claims the plugin is published on npm and provides a live demo URL, but no independent verification of the npm package or GitHub repository accessibility was provided within the PR itself.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after confirming that the npm scope @guanxing1 and the GitHub user doggychip belong to the same author.
- The registry entry is syntactically correct, alphabetically placed, and follows all formatting rules. The only concern preventing a higher score is the unexplained divergence between the npm scope (@guanxing1) and the GitHub username (doggychip), which makes it non-trivial for maintainers to verify that the submitter legitimately controls both endpoints. Once that ownership link is clarified, this is a low-risk, single-line registry addition.
- index.json — verify that the npm scope @guanxing1 and GitHub user doggychip are controlled by the same author before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds a single registry entry mapping the npm package `@guanxing1/plugin-elizaos` to `github:doggychip/plugin-guanxing`; JSON format, alphabetical ordering, and `github:` prefix are all correct. Minor concern: the npm scope (`@guanxing1`) and GitHub username (`doggychip`) are different identities, making ownership harder to verify at a glance. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as ElizaOS CLI
    participant Registry as Registry index.json
    participant GH as GitHub doggychip/plugin-guanxing
    participant NPM as npm @guanxing1/plugin-elizaos

    User->>CLI: elizaos plugins install @guanxing1/plugin-elizaos
    CLI->>Registry: Lookup @guanxing1/plugin-elizaos
    Registry-->>CLI: github:doggychip/plugin-guanxing
    CLI->>GH: Fetch plugin source and package.json
    GH-->>CLI: Plugin code plus agentConfig metadata
    CLI->>NPM: Optionally resolve published package
    NPM-->>CLI: Published package artifacts
    CLI-->>User: Plugin installed and ready
```

<sub>Last reviewed commit: ["feat: add @guanxing1..."](https://github.com/elizaos-plugins/registry/commit/5f8b2916f7233816feae1a2bb8f9c839b74bfedb)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->