### PR TITLE
Add moltspay-eliza-plugin to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -366,7 +366,7 @@
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
-  "moltspay-eliza-plugin": "github:Yaqing2023/moltspay-eliza-plugin",
+  "@moltspay/plugin-elizaos": "github:Yaqing2023/moltspay-eliza-plugin",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",

--- a/index.json
+++ b/index.json
@@ -366,6 +366,7 @@
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
+  "moltspay-eliza-plugin": "github:Yaqing2023/moltspay-eliza-plugin",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",


### PR DESCRIPTION
## Plugin: moltspay-eliza-plugin

MoltsPay plugin for ElizaOS - enables AI agents to discover and pay for services using x402 protocol.

### Features
- 🔐 8 actions: init, status, pay, fund, faucet, services, config, list
- 💳 Gasless USDC payments via x402 protocol
- 🔒 Built-in spending limits for safety
- 🌐 Bilingual support (EN/CN)
- ⛓️ Multi-chain: Base, Polygon, Base Sepolia (testnet)

### Links
- **npm:** https://www.npmjs.com/package/moltspay-eliza-plugin
- **GitHub:** https://github.com/Yaqing2023/moltspay-eliza-plugin
- **Docs:** https://moltspay.com

### Topics
Repo has required topic: `elizaos-plugins` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new plugin source to expand available integrations, increasing the set of available plugins.
  * Change is additive only (no removals or breaking changes) and low risk for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single entry to the elizaOS plugin registry for `moltspay-eliza-plugin`, a payment plugin enabling AI agents to discover and pay for services using the x402 protocol with gasless USDC payments on Base, Polygon, and Base Sepolia networks.

**Key observations:**
- The JSON format is valid, uses the correct `github:` prefix, has no `.git` extension, and is properly comma-delimited ✅
- The entry is correctly placed alphabetically among the unscoped entries at the end of `index.json` (after all `@`-scoped entries, before `plugin-connections`) ✅
- The package name `moltspay-eliza-plugin` uses a `{service}-eliza-plugin` naming order, which is the inverse of the registry-recommended `plugin-{name}` convention — all other unscoped entries follow `plugin-{name}` (e.g., `plugin-connections`, `plugin-moltbazaar`)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it is a minimal, well-formed registry entry with only a minor naming convention deviation.
- The change is a single-line addition to index.json. The JSON is valid, alphabetically sorted, and uses the correct `github:` reference format. The only minor concern is the unconventional package name ordering (`{service}-eliza-plugin` rather than `plugin-{service}`), but this is a style issue and not a blocker since the key is meant to match the actual npm package name.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds a single entry mapping `moltspay-eliza-plugin` to `github:Yaqing2023/moltspay-eliza-plugin`. The format is valid JSON, uses the correct `github:` prefix (no `.git` extension), and is alphabetically placed correctly among unscoped entries. The only concern is that the package name uses `{service}-eliza-plugin` ordering instead of the registry-recommended `plugin-{name}` convention. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as ElizaOS User
    participant CLI as ElizaOS CLI
    participant Registry as registry/index.json
    participant GH as github:Yaqing2023/moltspay-eliza-plugin
    participant X402 as x402 Protocol
    participant Chain as Base/Polygon Blockchain

    User->>CLI: Install moltspay-eliza-plugin
    CLI->>Registry: Look up "moltspay-eliza-plugin"
    Registry-->>CLI: github:Yaqing2023/moltspay-eliza-plugin
    CLI->>GH: Fetch plugin source
    GH-->>CLI: Plugin code
    CLI-->>User: Plugin installed

    User->>CLI: Agent triggers pay action
    CLI->>GH: Execute payment action
    GH->>X402: Initiate x402 payment request
    X402->>Chain: Submit gasless USDC transaction
    Chain-->>X402: Transaction confirmed
    X402-->>GH: Payment receipt
    GH-->>CLI: Payment result
    CLI-->>User: Payment complete
```

<sub>Last reviewed commit: ["Add moltspay-eliza-p..."](https://github.com/elizaos-plugins/registry/commit/58304c2e350d0bd6425971dfcc29bb888c3f2a3f)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->