### PR TITLE
Add @jhinresh/plugin-maiat-trust

### DIFF
--- a/index.json
+++ b/index.json
@@ -224,6 +224,7 @@
    "@elizaos/plugin-zytron": "github:zypher-network/plugin-zytron",
    "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
    "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
+   "@jhinresh/plugin-maiat-trust": "github:JhiNResH/plugin-maiat-trust",
    "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
    "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
    "@mascotai/plugin-connections": "github:mascotai/plugin-connections",


### PR DESCRIPTION
**Maiat Trust** — Trust scoring plugin for ElizaOS agents.

**Package:** `@jhinresh/plugin-maiat-trust`
**Repo:** https://github.com/JhiNResH/plugin-maiat-trust

**Actions provided:**
- `CHECK_TRUST` — Behavioral trust score for agent wallets (18K+ agents indexed)
- `CHECK_TOKEN` — Token safety check (honeypot, rug pull, liquidity risks)
- `TRUST_SWAP` — Trust-verified swap quotes with safety checks
- `REPORT_OUTCOME` — Feedback loop for trust score accuracy

**Dependencies:** `@jhinresh/maiat-sdk`

Built on Maiat Protocol (https://app.maiat.io) — trust infrastructure for the agent economy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new package: `@jhinresh/plugin-maiat-trust`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers a single new entry in the plugin registry — `@jhinresh/plugin-maiat-trust` pointing to `github:JhiNResH/plugin-maiat-trust` — for a trust scoring plugin that provides `CHECK_TRUST`, `CHECK_TOKEN`, `TRUST_SWAP`, and `REPORT_OUTCOME` actions built on the Maiat Protocol.

**Key concerns:**
- The target GitHub repository `JhiNResH/plugin-maiat-trust` could not be found as a publicly accessible repository in search results. Without a publicly reachable repository, users will be unable to install the plugin, making the registry entry non-functional.
- The author's official Maiat Protocol repository (`JhiNResH/maiat-protocol`) publishes the ElizaOS integration under a **different** npm package name: `@jhinresh/elizaos-plugin`. The name `@jhinresh/plugin-maiat-trust` does not appear in any published package or repository that could be discovered publicly.
- The alphabetical ordering in `index.json` is correct — the new entry is properly inserted between `@esscrypt/plugin-polkadot` and `@kamiyo/eliza`.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge — the referenced GitHub repository does not appear to exist publicly, and the registered package name differs from the author's known published ElizaOS plugin.
- The sole change is a registry mapping, and its value (`github:JhiNResH/plugin-maiat-trust`) points to a repository that could not be verified as publicly accessible. Additionally, the package name `@jhinresh/plugin-maiat-trust` is inconsistent with the author's documented ElizaOS package (`@jhinresh/elizaos-plugin`). A broken or missing repository would render the registry entry unusable for any ElizaOS user trying to install this plugin.
- index.json — the new registry entry at line 227 needs the GitHub repository URL to be verified as publicly accessible before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds a single registry entry for `@jhinresh/plugin-maiat-trust` → `github:JhiNResH/plugin-maiat-trust`; the target repository does not appear to be publicly accessible and the package name does not match the author's known published ElizaOS plugin (`@jhinresh/elizaos-plugin`). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as ElizaOS User
    participant Registry as Plugin Registry (index.json)
    participant GH as github:JhiNResH/plugin-maiat-trust
    participant SDK as @jhinresh/maiat-sdk
    participant API as Maiat Protocol API (app.maiat.io)

    User->>Registry: npm install @jhinresh/plugin-maiat-trust
    Registry->>GH: Resolve github:JhiNResH/plugin-maiat-trust
    Note over GH: ⚠️ Repository not found publicly
    GH-->>User: Resolution error (if repo is missing/private)

    Note over User,API: Expected happy path (if repo exists)
    GH-->>User: Plugin source downloaded
    User->>SDK: Plugin loads @jhinresh/maiat-sdk
    SDK->>API: CHECK_TRUST / CHECK_TOKEN / TRUST_SWAP / REPORT_OUTCOME
    API-->>SDK: Trust score / token safety / swap quote
    SDK-->>User: Action result returned to agent
```

<sub>Last reviewed commit: ["Add @jhinresh/plugin..."](https://github.com/elizaos-plugins/registry/commit/2358f2807d3f3e8cb92699dabdfc3ce621bff792)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->