### PR TITLE
feat: add @x402-index/plugin-x402search

### DIFF
--- a/index.json
+++ b/index.json
@@ -365,6 +365,7 @@
   "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
+  "@x402-index/plugin-x402search": "github:x402-index/plugin-x402search",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",


### PR DESCRIPTION
## Plugin Registration: @x402-index/plugin-x402search

Adds x402search to the ElizaOS plugin registry — a pay-per-search API discovery engine for AI agents.

### Verification Checklist
- [x] Repository is publicly accessible: https://github.com/x402-index/plugin-x402search
- [x] Default branch is `main`
- [x] Repository topics include `elizaos-plugin`
- [x] Only `index.json` is modified
- [x] Entry is alphabetically sorted
- [x] Plugin performs x402 micropayments ($0.01 USDC on Base mainnet) — consistent with other x402 plugins in the registry

### Plugin Details
- **Package:** `@x402-index/plugin-x402search`
- **Repo:** `github:x402-index/plugin-x402search`
- **Function:** Natural language search across 14,000+ indexed x402-enabled HTTP APIs
- **Cost:** $0.01 USDC per query via x402 protocol on Base mainnet
- **No API keys required** — payment is the auth mechanism