### PR TITLE
Add @tsmets/plugin-arcadia to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -365,6 +365,7 @@
   "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
+    "@tsmets/plugin-arcadia": "github:Thomas-Smets/plugin-arcadia",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",


### PR DESCRIPTION
This PR adds @tsmets/plugin-arcadia to the registry.

- Package name: @tsmets/plugin-arcadia
- GitHub repository: github:Thomas-Smets/plugin-arcadia
- Version: 0.1.0
- Description: Arcadia Finance: manage concentrated liquidity on Uniswap and Aerodrome with automated rebalancing and yield optimization on Base.

Submitted by: @Thomas-Smets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `@tsmets/plugin-arcadia` plugin is now available for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers the `@tsmets/plugin-arcadia` package in the elizaos-plugins registry. The plugin is described as a DeFi tool for managing concentrated liquidity on Uniswap and Aerodrome with automated rebalancing and yield optimization on Base.

- The entry is correctly placed in alphabetical order (between `@tonyflam/plugin-openchat` and `@zane-archer/plugin-aimo-router`)
- The new entry uses **4-space indentation** instead of the **2-space indentation** used by every other entry in `index.json` — this should be corrected for consistency
- The GitHub reference `github:Thomas-Smets/plugin-arcadia` follows the correct format used by other entries in the registry

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the minor indentation inconsistency on the new registry entry.
- The change is a single-line addition to a JSON registry file. The entry is alphabetically ordered correctly and uses the proper `github:owner/repo` format. The only issue is a cosmetic 4-space vs 2-space indentation inconsistency that doesn't affect JSON validity but breaks file formatting conventions.
- No files require special attention beyond the minor indentation fix in `index.json`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Single entry added for `@tsmets/plugin-arcadia` pointing to `github:Thomas-Smets/plugin-arcadia`. Entry is correctly placed in alphabetical order between `@tonyflam` and `@zane-archer`, but uses 4-space indentation instead of the 2-space convention used by all other entries in the file. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: Add @tsmets/plugin-arcadia] --> B{Entry validation}
    B --> C[Alphabetical order ✅]
    B --> D[github: URL format ✅]
    B --> E[Indentation: 4 spaces ❌\nExpected: 2 spaces]
    C --> F[registry/index.json updated]
    D --> F
    E --> G[Style fix required]
    G --> F
```

<sub>Last reviewed commit: ["Add @tsmets/plugin-a..."](https://github.com/elizaos-plugins/registry/commit/b2608abd159cd2d7571447afe60df94879bbae48)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->