### PR TITLE
@zero-nium/plugin-project-substitute

### DIFF
--- a/index.json
+++ b/index.json
@@ -366,7 +366,7 @@
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
-  "@zero-nium/plugin-project-substitute": "@zero-nium/plugin-project-substitute",
+  "@zero-nium/plugin-project-substitute": "github:Zero-nium/plugin-project-substitute",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",

--- a/index.json
+++ b/index.json
@@ -366,6 +366,7 @@
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
+  "@zero-nium/plugin-project-substitute": "@zero-nium/plugin-project-substitute",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",


### PR DESCRIPTION
Adds ElizaOS plugin for Project Substitute Arena — a counterfactual CEO simulation where agents replace the CEO of Toys R Us (2006-2017).

- npm: https://www.npmjs.com/package/@zero-nium/plugin-project-substitute
- Live service: https://zero-wispy-shadow-3951.fly.dev
- Free entry, no deposit required
- 5 actions: get scenario, register, check status, get results, cohort analysis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Registered a new plugin package in the package index to make the plugin available for discovery and installation.
  * Confirmed this addition did not modify any existing package mappings or other registrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single entry to `index.json` for `@zero-nium/plugin-project-substitute`, an ElizaOS plugin for a counterfactual CEO simulation game. The change itself is minimal (one line), but the entry's value does not conform to the registry's required format.

**Key issues found:**
- The registry value `"@zero-nium/plugin-project-substitute"` is a bare npm package name, not a GitHub repository reference. Every other entry in the registry uses the `github:org/repo` format explicitly required by the README and the PR checklist. This will likely cause the automated `generated-registry.json` generation workflow to fail, since it processes entries by cloning GitHub repositories to gather version tags, branch info, and plugin metadata.
- No public GitHub source repository is linked, making it impossible to verify plugin structure, branding assets (`images/logo.jpg`, `images/banner.jpg`), `agentConfig` in `package.json`, or any of the other checklist requirements.

<h3>Confidence Score: 1/5</h3>

Not safe to merge — the registry value format is incorrect and will break the automated registry generation pipeline.

The single changed line has a clear format violation: the value must be `github:org/repo` per the documented spec, but is instead a bare npm package name that self-references the key. This is not merely a style issue — the GitHub Actions workflow that generates `generated-registry.json` depends on parsing `github:` prefixed values to clone repositories. Additionally, without a public GitHub repo linked, none of the required checklist items (branding assets, `agentConfig`, plugin structure, topics) can be verified.

index.json line 369 — invalid registry value format.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds @zero-nium/plugin-project-substitute entry, but the value is a bare npm package name instead of the required `github:org/repo` format, violating the registry format specification. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PR merges index.json entry"] --> B["GitHub Action triggers on push to main"]
    B --> C["Action reads each entry in index.json"]
    C --> D{Value starts with 'github:'?}
    D -- Yes --> E["Clone repo & gather metadata\n(versions, branches, agentConfig)"]
    E --> F["Write to generated-registry.json"]
    D -- No --> G["❌ Fails / skips entry\n(current PR value: '@zero-nium/plugin-project-substitute')"]
    G --> H["generated-registry.json missing plugin entry"]
```

<sub>Reviews (1): Last reviewed commit: ["Add @zero-nium/plugin-project-substitute"](https://github.com/elizaos-plugins/registry/commit/28bd13528716cd96b31612b1da6a9380bd543476) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26417540)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->