### PR TITLE
feat: Add plugin-undesirables — 4,444 AI Agent Souls

### DIFF
--- a/index.json
+++ b/index.json
@@ -369,5 +369,6 @@
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",
-  "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402"
+  "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402",
+  "plugin-undesirables": "github:sailorpepe/plugin-undesirables"
 }


### PR DESCRIPTION

<img width="1280" height="640" alt="og_preview" src="https://github.com/user-attachments/assets/4f293233-f24d-4232-8804-798ff3372004" />

## Plugin: plugin-undesirables

**The Undesirables** — 4,444 autonomous AI agents on Ethereum, each with unique personality traits, trading strategies, and 23 built-in skills.

### What it adds to ElizaOS

| Action | Description |
|--------|-------------|
| `UNDESIRABLE_MARKET_ANALYSIS` | Personality-driven market analysis with risk guardrails |
| `UNDESIRABLE_BUSINESS_PILOT` | 23 AI-powered business automation modules |
| `UNDESIRABLE_MEME_MACHINE` | Content creation, meme templates, industry packs |
| `UNDESIRABLE_LOAD_SKILL` | Auto-matches and loads any of 23 skills |

Plus a `soulProvider` that injects agent personality context into every conversation.

### Links
- **npm**: https://www.npmjs.com/package/plugin-undesirables
- **GitHub**: https://github.com/sailorpepe/plugin-undesirables
- **MCP Server**: https://github.com/sailorpepe/undesirables-mcp-server
- **Tutorial**: https://github.com/sailorpepe/undesirables-mcp-server/blob/main/TUTORIAL.md
- **Website**: https://the-undesirables.com
- **Docs**: https://the-undesirables.com/docs

### Tech
- Local Ollama inference (zero API costs)
- 4,444 unique soul personalities derived from NFT visual traits
- Big Five personality model + architype-driven trading strategies
- Token-gated workspace download
- MCP-compliant (works with Cursor, Claude Desktop, VS Code)

### Previous Contribution
- PR #505 merged to Milady/ElizaOS (whitelist integration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new plugin to the plugin registry for additional functionality.

* **Chores**
  * Adjusted registry ordering and formatting to improve consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new community plugin entry `plugin-undesirables → github:sailorpepe/plugin-undesirables` to the elizaOS plugin registry. The plugin is described as an NFT-backed agent framework providing personality-driven market analysis, business automation, meme generation, and skill loading actions — with some features being token-gated behind NFT ownership.\n\n**Changes made:**\n- Adds `\"plugin-undesirables\": \"github:sailorpepe/plugin-undesirables\"` at the end of the unscoped entries section, alphabetically correct after `plugin-otaku-x402`\n- Silently repositions the pre-existing `@elizaos/plugin-ATTPs` entry from between `plugin-8004`/`plugin-abstract` (case-sensitive position) to between `plugin-asterai`/`plugin-auto-trader` (case-insensitive correct position) — this change is not documented in the PR description\n- Adds a trailing newline at end of file (was missing)\n\n**Key points:**\n- The new entry format is correct: uses `github:` prefix, no `.git` extension, matches the claimed npm package name\n- The unscoped package key (`plugin-undesirables` without `@scope/`) is consistent with several other existing unscoped registry entries\n- The undocumented repositioning of `@elizaos/plugin-ATTPs` is a minor process concern and should be documented or handled separately

<h3>Confidence Score: 4/5</h3>

Safe to merge after confirming the npm package name is unscoped and acknowledging the ATTPs repositioning

The new `plugin-undesirables` entry is technically well-formed (correct `github:` format, no `.git`, properly alphabetized, and the claimed npm package name matches the key). The only notable issue is the undocumented repositioning of the existing `@elizaos/plugin-ATTPs` entry — while the new position is alphabetically more correct under case-insensitive ordering, it is an undocumented side-effect that should be acknowledged. This is a P2 style concern and does not block merging.

Only `index.json` is changed; the `@elizaos/plugin-ATTPs` repositioning on lines 37–59 warrants a quick review alongside the new entry at line 373

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `plugin-undesirables → github:sailorpepe/plugin-undesirables` in correctly sorted position; also silently repositions the pre-existing `@elizaos/plugin-ATTPs` entry for case-insensitive alphabetical correctness (undocumented side-effect) |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: feat/plugin-undesirables] --> B{index.json changes}
    B --> C[New entry added\nplugin-undesirables\n→ github:sailorpepe/plugin-undesirables]
    B --> D[Existing entry repositioned\n@elizaos/plugin-ATTPs\nmoved to case-insensitive\ncorrect position]
    C --> E{Format checks}
    E --> E1[✅ github: prefix]
    E --> E2[✅ No .git extension]
    E --> E3[✅ Alphabetically sorted\nafter plugin-otaku-x402]
    E --> E4[⚠️ Unscoped key — confirm\nnpm package name]
    D --> F[⚠️ Undocumented change\nto pre-existing entry]
    C --> G[GitHub Action triggers\ngenerated-registry.json update]
```

<sub>Reviews (1): Last reviewed commit: ["feat: Add plugin-undesirables to registr..."](https://github.com/elizaos-plugins/registry/commit/697a6ad77b1448a15edc8e7bbe5177c1d70af8a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26448828)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->
