### PR TITLE
Add swarms-x402: x402 payments + Swarms multi-agent orchestration (SwarmX)

### DIFF
--- a/index.json
+++ b/index.json
@@ -353,6 +353,7 @@
   "@elizaos/plugin-zytron": "github:zypher-network/plugin-zytron",
   "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
   "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
+  "@itachisol/plugin-x402-swarms": "github:ItachiDevv/eliza-x402-swarms",
   "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
   "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
   "@mascotai/plugin-connections": "github:mascotai/plugin-connections",
@@ -369,6 +370,5 @@
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",
-  "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402",
-  "plugin-x402-swarms": "github:ItachiDevv/eliza-x402-swarms"
+  "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402"
 }

--- a/index.json
+++ b/index.json
@@ -371,5 +371,5 @@
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",
   "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402",
-  "plugin-x402-swarms": "github:ItachiDevv/eliza-x402-swarms"
+  "swarms-x402": "github:ItachiDevv/eliza-x402-swarms"
 }

--- a/index.json
+++ b/index.json
@@ -37,7 +37,6 @@
   "@elizaos/plugin-0x": "github:elizaos-plugins/plugin-0x",
   "@elizaos/plugin-3d-generation": "github:elizaos-plugins/plugin-3d-generation",
   "@elizaos/plugin-8004": "github:elizaos-plugins/plugin-8004",
-  "@elizaos/plugin-ATTPs": "github:APRO-com/plugin-ATTPs",
   "@elizaos/plugin-abstract": "github:elizaos-plugins/plugin-abstract",
   "@elizaos/plugin-acp": "github:elizaos-plugins/plugin-acp",
   "@elizaos/plugin-action-bench": "github:elizaos-plugins/plugin-action-bench",
@@ -57,6 +56,7 @@
   "@elizaos/plugin-arkham": "github:elizaos-plugins/plugin-arkham",
   "@elizaos/plugin-arthera": "github:elizaos-plugins/plugin-arthera",
   "@elizaos/plugin-asterai": "github:elizaos-plugins/plugin-asterai",
+  "@elizaos/plugin-ATTPs": "github:APRO-com/plugin-ATTPs",
   "@elizaos/plugin-auto-trader": "github:elizaos-plugins/plugin-auto-trader",
   "@elizaos/plugin-autocoder": "github:elizaos-plugins/plugin-autocoder",
   "@elizaos/plugin-autofun": "github:elizaos-plugins/plugin-autofun",
@@ -369,5 +369,6 @@
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",
-  "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402"
+  "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402",
+  "plugin-x402-swarms": "github:ItachiDevv/eliza-x402-swarms"
 }

--- a/index.json
+++ b/index.json
@@ -353,7 +353,7 @@
   "@elizaos/plugin-zytron": "github:zypher-network/plugin-zytron",
   "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
   "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
-  "@itachisol/plugin-x402-swarms": "github:ItachiDevv/eliza-x402-swarms",
+  
   "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
   "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
   "@mascotai/plugin-connections": "github:mascotai/plugin-connections",
@@ -370,5 +370,6 @@
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",
-  "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402"
+  "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402",
+  "plugin-x402-swarms": "github:ItachiDevv/eliza-x402-swarms"
 }


### PR DESCRIPTION
## Summary

Adds **SwarmX** (`plugin-x402-swarms`) — an ElizaOS v2 plugin and standalone platform for x402 micropayments + Swarms multi-agent orchestration.

## What it does

- **x402 Payments**: Agents can buy and sell APIs using USDC via the Dexter SDK (6 networks: Base, Ethereum, Solana, Polygon, Arbitrum)
- **Swarms Orchestration**: 15+ multi-agent architectures (Sequential, Concurrent, MixtureOfAgents, MajorityVoting, etc.)
- **16 paid endpoints**: Solana wallet analysis, token holders, DeFi positions, AI summarization, translation, code review, research pipelines, and more
- **4 pre-built templates**: ResearchPipeline, AnalysisPanel, CodeReview, DebateAndDecide
- **LLM routing**: Single-agent tasks call OpenAI directly (~95% margin), multi-agent tasks use Swarms API
- **Payment persistence**: Drizzle ORM schemas for payment history, endpoint quality scoring, cross-session budgets
- **Client SDK**: One-liner access to all endpoints via `createClient()`

## Links

- **Repo**: https://github.com/ItachiDevv/eliza-x402-swarms
- **Live platform**: https://x402-swarms-production.up.railway.app
- **OpenDexter**: 10 endpoints indexed and discoverable
- **Tests**: 331 passing

## Implements

TypeScript/ElizaOS implementation of the official Swarms x402 tutorial by Kye Gomez:
https://medium.com/@kyeg/how-to-monetize-your-agents-with-swarms-and-x402-a-simple-step-by-step-tutorial-e56bacc2daf2

## Plugin Components

| Component | Count |
|-----------|-------|
| Actions | 5 |
| Services | 4 |
| Providers | 2 |
| Evaluators | 1 |
| Routes | 19 |
| Templates | 4 |
| DB Schemas | 3 |

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the swarms-x402 plugin to the registry, expanding available integrations.

* **Chores**
  * Reordered a registry entry (moved an existing plugin without changing its mapping).
  * Minor formatting and whitespace cleanup, including adding a trailing newline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers `plugin-x402-swarms` — an ElizaOS v2 plugin combining x402 micropayments via the Dexter SDK with Swarms multi-agent orchestration — by adding a single entry to `index.json`. It also incidentally corrects the alphabetical position of an existing entry (`@elizaos/plugin-ATTPs`).

**Key observations:**
- The JSON remains valid and the new entry uses the correct `github:` format with no `.git` extension.
- The new entry is correctly placed alphabetically at the end of the unnamespaced section (`plugin-x402-swarms` follows `plugin-otaku-x402`, since `x` > `o`).
- The registry key `plugin-x402-swarms` must match the `"name"` field in the plugin's `package.json` exactly for the ElizaOS CLI to resolve the plugin correctly — this alignment could not be confirmed since the repo name (`eliza-x402-swarms`) differs from the key.
- The `@elizaos/plugin-ATTPs` reordering is alphabetically correct but was not mentioned in the PR description.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the registry key is confirmed to match the plugin's npm package name exactly.

The JSON change is minimal, valid, and correctly formatted. The only outstanding concern is a potential mismatch between the registry key (`plugin-x402-swarms`) and the actual npm package name declared in the external repo's `package.json` — if they don't match, the plugin will fail to load via the CLI. This warrants author confirmation before merging.

index.json — specifically the new `plugin-x402-swarms` entry at line 373; the npm package name in the plugin's `package.json` should be verified to match this key exactly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `plugin-x402-swarms` → `github:ItachiDevv/eliza-x402-swarms`; also repositions `@elizaos/plugin-ATTPs` alphabetically. JSON is valid, format is correct, but the npm package name alignment with the registry key and the existence/completeness of the external repo cannot be fully verified. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: Add plugin-x402-swarms] --> B[Modify index.json]
    B --> C[Add new entry
plugin-x402-swarms
github:ItachiDevv/eliza-x402-swarms]
    B --> D[Reorder existing entry
@elizaos/plugin-ATTPs
moved to alphabetical position]
    C --> E{Key matches
package.json name?}
    E -- Yes --> F[Registry Generation
GitHub Action runs]
    E -- No --> G[Plugin fails to load
in ElizaOS CLI]
    F --> H[generated-registry.json updated]
    H --> I[Plugin discoverable
via CLI & Web Registry]
```

<sub>Reviews (1): Last reviewed commit: ["Add plugin-x402-swarms: x402 micropaymen..."](https://github.com/elizaos-plugins/registry/commit/7cb418ca44bac3e36c0470f7519285b53e6f811b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26545938)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->