### PR TITLE
Add @desideapp/plugin-deside to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -6,6 +6,7 @@
   "@bealers/plugin-mattermost": "github:bealers/plugin-mattermost",
   "@blockrun/elizaos-plugin": "github:BlockRunAI/elizaos-plugin-blockrun",
   "@coinrailz/plugin-coinrailz": "github:tdnupe3/coinrailz-eliza-plugin",
+  "@desideapp/plugin-deside": "github:DesideApp/plugin-deside",
   "@elizaos/adapter-mongodb": "github:elizaos-plugins/adapter-mongodb",
   "@elizaos/adapter-pglite": "github:elizaos-plugins/adapter-pglite",
   "@elizaos/adapter-postgres": "github:elizaos-plugins/adapter-postgres",


### PR DESCRIPTION
# Registry Update Checklist

Registry:
- [x] I've made the left side of the colon of JSON entry in index.json match the potential NPM package name
- [x] I've used github not github.com
- [x] There is no .git extension
- [x] It's placed it alphabetically in the list
- [x] I've dealt with commas properly so the list is still valid JSON

If not an eliza-plugins official repo, i.e. new plugin: 

The plugin repo has:
- [x] is publically accessible (not a private repo)
- [x] uses main as it's default branch
- [x] I have include `elizaos-plugins` in the topics in the GitHub repo settings. If the plugin is related to `AI` or `crypto`, please add those as topics as well.
- [x] add simple description in github repo
- [x] follows this convention
- [x] an `images/banner.jpg` and `images/logo.jpg` and they
  - Use clear, high-resolution images
  - Keep file sizes optimized (< 500KB for logos, < 1MB for banners)
  - Follow the [elizaOS Brand Guidelines](https://github.com/elizaOS/brandkit)
  - Include alt text for accessibility
- [x] package.json has a agentConfig like the following

## Discord username

M.Rohe#7469

Add `@desideapp/plugin-deside` to the elizaOS plugin registry.

Plugin repo:
- https://github.com/DesideApp/plugin-deside

NPM package:
- https://www.npmjs.com/package/@desideapp/plugin-deside

The plugin is already published and available for external installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Registered a new plugin package in the system registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single entry for `@desideapp/plugin-deside` to the elizaOS plugin registry (`index.json`). It also incidentally fixes the missing newline at the end of the file.

- The new entry follows the correct format: `\"@desideapp/plugin-deside\": \"github:DesideApp/plugin-deside\"`
- Uses the `github:` scheme (not `github.com:`) with no `.git` suffix — both correct.
- The left-hand key matches the published NPM package name `@desideapp/plugin-deside`.
- The entry is correctly placed in alphabetical order between `@coinrailz/plugin-coinrailz` and `@elizaos/adapter-mongodb`.
- Commas are handled correctly and the JSON remains valid.
- The trailing newline fix is a minor, welcome housekeeping improvement.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the entry is well-formed, correctly ordered, and follows all registry conventions.

The change is a single-line registry addition with no logic, no code execution risk, and no JSON validity concerns. All checklist items in the PR description appear satisfied, and no P1 or P0 issues were identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `@desideapp/plugin-deside` registry entry in correct alphabetical position; also fixes missing newline at end of file. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: Add @desideapp/plugin-deside] --> B{Checklist Validation}
    B --> C[Key matches NPM package name ✅]
    B --> D[Uses github: scheme, no .git ✅]
    B --> E[Alphabetical order ✅]
    B --> F[Valid JSON / commas ✅]
    B --> G[Newline at EOF fixed ✅]
    C & D & E & F & G --> H[index.json updated]
    H --> I[Plugin discoverable in elizaOS registry]
```

<sub>Reviews (1): Last reviewed commit: ["Add @desideapp/plugin-deside to registry"](https://github.com/elizaos-plugins/registry/commit/a5440b1744d460527d20aa1acdc214fac6f815bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26652675)</sub>

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->