### PR TITLE
feat: add @wzrd_sol/eliza-plugin — AI model velocity signals

### DIFF
--- a/index.json
+++ b/index.json
@@ -365,6 +365,7 @@
   "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
+  "@wzrd_sol/eliza-plugin": "github:twzrd-sol/eliza-plugin",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",


### PR DESCRIPTION
## Plugin: @wzrd_sol/eliza-plugin

**npm**: https://www.npmjs.com/package/@wzrd_sol/eliza-plugin (v0.2.0)
**repo**: https://github.com/twzrd-sol/eliza-plugin
**version**: 0.2.0
**peer**: @elizaos/core ^1.0.0 (tested with 1.7.2)

### What it does

WZRD velocity oracle plugin for ElizaOS. Enables agents to discover trending AI models across 4 platforms (HuggingFace, OpenRouter, GitHub, ArtificialAnalysis), run server-witnessed inference, and earn CCM rewards on Solana.

### Actions

| Action | Description |
|--------|-------------|
| WZRD_INFER | Server-witnessed inference with quality scoring |
| WZRD_REPORT | Report model picks with execution receipts |
| WZRD_EARN | Full earn cycle: infer → report → check rewards |
| WZRD_CLAIM | Gasless CCM claims via relay |
| WZRD_REWARDS | Check pending/lifetime CCM balance |

### Dependencies

Only 3 production deps: @solana/web3.js, bs58, tweetnacl.

### Testing

20/20 E2E tests passing against live API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added package dependency configuration to support a new plugin integration. Updated file formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single registry entry mapping the `@wzrd_sol/eliza-plugin` npm package to its GitHub source (`github:twzrd-sol/eliza-plugin`). It also incidentally fixes the pre-existing missing newline at end of `index.json`.

**Key observations:**
- **Format is correct**: the entry follows the `\"@npm-package-name\": \"github:org/repo\"` pattern used throughout the registry.
- **Alphabetical ordering is correct**: the new entry is placed between `@tonyflam/plugin-openchat` (`t` < `w`) and `@zane-archer/plugin-aimo-router` (`w` < `z`).
- **Scope name uses underscore** (`@wzrd_sol`): this is valid per npm's specification — underscores are permitted within scoped package names — but is notably different from the hyphen-only convention used by every other scoped entry in this registry. This is cosmetic and not a blocker.
- **GitHub slug vs npm scope mismatch**: the npm scope is `@wzrd_sol` (underscore) while the GitHub username is `twzrd-sol` (hyphen, different string). Both are consistent with the PR description, so this appears intentional.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line registry addition with correct format, alphabetical ordering, and no code changes.

The only changed file is `index.json`, with one new key-value entry that follows the correct registry format and is correctly sorted. No logic, no executable code, and the pre-existing missing-newline issue is also fixed in this PR.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `@wzrd_sol/eliza-plugin` → `github:twzrd-sol/eliza-plugin` mapping; correctly placed alphabetically between `@tonyflam` and `@zane-archer`; also fixes the pre-existing missing newline at end of file. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User / Agent
    participant Registry as elizaOS Registry (index.json)
    participant GitHub as github:twzrd-sol/eliza-plugin
    participant NPM as npm (@wzrd_sol/eliza-plugin)

    User->>Registry: look up "@wzrd_sol/eliza-plugin"
    Registry-->>User: "github:twzrd-sol/eliza-plugin"
    User->>GitHub: install plugin source
    GitHub-->>User: plugin code (v0.2.0)
    Note over User,NPM: NPM package listed separately at npmjs.com/@wzrd_sol/eliza-plugin
```

<sub>Reviews (1): Last reviewed commit: ["feat: add @wzrd\_sol/eliza-plugin — AI mo..."](https://github.com/elizaos-plugins/registry/commit/0d10c32d5c6b898e52c62060f046bb7680a47b06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26731299)</sub>

<!-- /greptile_comment -->