### PR TITLE
feat: add @elizaos/plugin-bsc-memes

### DIFF
--- a/index.json
+++ b/index.json
@@ -84,6 +84,7 @@
   "@elizaos/plugin-bnv-me-id": "github:brand-new-vision/plugin-bnv-me-id",
   "@elizaos/plugin-bootstrap": "github:elizaos-plugins/plugin-bootstrap",
   "@elizaos/plugin-browser": "github:elizaos-plugins/plugin-browser",
+  "@elizaos/plugin-bsc-memes": "github:milady-ai/plugin-bsc-memes",
   "@elizaos/plugin-cardano": "github:relipasoft/plugin-cardano",
   "@elizaos/plugin-ccxt": "github:pranavjadhav1363/plugin-ccxt",
   "@elizaos/plugin-cerebras": "github:Xayaan/plugin-cerebras",


### PR DESCRIPTION
Adds BSC meme token trading plugin for elizaOS agents.

**Plugin:** `@elizaos/plugin-bsc-memes`
**Repo:** https://github.com/milady-ai/plugin-bsc-memes

Supports Flap and FourMeme protocols on BNB Smart Chain:
- Buy, sell, launch meme tokens
- Browse trending tokens
- Slippage protection and confirmation flows

Created by milady-ai team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the BSC Memes plugin as a new available integration, providing users with expanded functionality for interacting with BSC meme-related features.

* **Chores**
  * Updated the plugin registry system to properly register the BSC Memes plugin mapping and resolved file formatting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single entry to `index.json` registering `@elizaos/plugin-bsc-memes` (hosted at `github:milady-ai/plugin-bsc-memes`) as a community plugin for BSC meme token trading. It also incidentally fixes the missing newline at the end of `index.json`.

- The entry follows the correct registry format (`"@npm-package-name": "github:org/repo"`)
- The new entry is correctly placed in alphabetical order between `@elizaos/plugin-browser` and `@elizaos/plugin-cardano`
- The plugin is hosted under the `milady-ai` GitHub organization (not `elizaos-plugins`), which is consistent with other community entries in the registry (e.g., `@elizaos/plugin-bnv-me-id` → `github:brand-new-vision/plugin-bnv-me-id`)
- The PR description is minimal and does not include the working demo evidence, integration testing proof, or configuration examples that the `README.md` explicitly requires for registry submissions

<h3>Confidence Score: 3/5</h3>

The JSON entry itself is correctly formatted and ordered, but the referenced repository cannot be independently verified and the PR is missing demo/testing evidence required by the contributing guidelines.

The single-line change is mechanically correct (proper format, correct alphabetical position, valid github:org/repo reference, newline fix). However, the registry README explicitly requires working demo evidence, integration testing proof, and a quality checklist — none of which are present in this PR. Additionally, the repository is hosted under a third-party org (milady-ai) using the @elizaos/ npm namespace; while this pattern exists for other entries, it warrants confirmation that the namespace usage is authorized. Score is 3 rather than lower because the JSON change itself poses no technical risk to the registry file.

No files require special attention beyond the standard registry review checklist for index.json.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds one registry entry for @elizaos/plugin-bsc-memes pointing to github:milady-ai/plugin-bsc-memes; alphabetical ordering and JSON format are correct; also fixes missing newline at EOF |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ElizaOS CLI
    participant Registry (index.json)
    participant GitHub (milady-ai/plugin-bsc-memes)
    participant BSC (FourMeme / Flap)

    User->>ElizaOS CLI: Install @elizaos/plugin-bsc-memes
    ElizaOS CLI->>Registry (index.json): Lookup @elizaos/plugin-bsc-memes
    Registry (index.json)-->>ElizaOS CLI: github:milady-ai/plugin-bsc-memes
    ElizaOS CLI->>GitHub (milady-ai/plugin-bsc-memes): Download & load plugin
    GitHub (milady-ai/plugin-bsc-memes)-->>ElizaOS CLI: Plugin loaded
    User->>ElizaOS CLI: Buy / Sell / Launch meme token
    ElizaOS CLI->>BSC (FourMeme / Flap): Execute on-chain transaction
    BSC (FourMeme / Flap)-->>ElizaOS CLI: Transaction result
    ElizaOS CLI-->>User: Confirmation / Result
```

<sub>Reviews (1): Last reviewed commit: ["feat: add @elizaos/plugin-bsc-memes (BSC..."](https://github.com/elizaos-plugins/registry/commit/7564345743d616586811d66cb72e42656303d8bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27188009)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->