### PR TITLE
Add @trustlayer/plugin-elizaos

### DIFF
--- a/index.json
+++ b/index.json
@@ -364,6 +364,7 @@
   "@standujar/plugin-composio": "github:standujar/plugin-composio",
   "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
+  "@trustlayer/plugin-elizaos": "github:goatgaucho/elizaos-plugin-trustlayer",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
   "plugin-connections": "github:mascotai/plugin-connections",


### PR DESCRIPTION
## Summary

Adds **@trustlayer/plugin-elizaos** to the ElizaOS plugin registry.

**Repository:** https://github.com/goatgaucho/elizaos-plugin-trustlayer

## What it does

TrustLayer is a reputation intelligence API for AI agents. The plugin provides:

- **TrustLayer Provider** — injects real-time agent reputation scores into ElizaOS agent context, enabling pre-transaction trust checks against any ERC-8004 registered agent across 20+ chains and Solana
- **getTrustScore Action** — lets ElizaOS agents query TrustLayer's scoring API on demand, returning a composite trust score based on profile completeness, feedback volume/quality, and Sybil detection

This enables ElizaOS agents to verify counterparty reputation before transacting — the credit bureau for the agent economy.

## Checklist

- [x] Only `index.json` modified
- [x] Entry added in alphabetical order
- [x] `images/logo.jpg` (400x400) present in repo
- [x] `images/banner.jpg` (1280x640) present in repo
- [x] `elizaos-plugins` topic added to repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for a new plugin package to the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `@trustlayer/plugin-elizaos` (a reputation intelligence plugin providing on-chain trust scoring for AI agents) to the ElizaOS plugin registry. The only issue is a minor alphabetical ordering mistake — `@tonyflam/plugin-openchat` should appear before `@trustlayer/plugin-elizaos` since `"ton" < "tru"`.

<h3>Confidence Score: 5/5</h3>

Safe to merge after fixing the minor alphabetical ordering issue

Only a P2 style issue (wrong sort order) was found; no logic, security, or data integrity issues present

index.json — swap lines 367 and 368 to restore alphabetical order

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds @trustlayer/plugin-elizaos registry entry; entry is inserted slightly out of alphabetical order (should follow @tonyflam, not precede it) |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as ElizaOS Agent
    participant Registry as Plugin Registry (index.json)
    participant Plugin as @trustlayer/plugin-elizaos
    participant API as TrustLayer API

    Agent->>Registry: lookup @trustlayer/plugin-elizaos
    Registry-->>Agent: github:goatgaucho/elizaos-plugin-trustlayer
    Agent->>Plugin: load plugin
    Plugin-->>Agent: register TrustLayer Provider + getTrustScore Action
    Agent->>API: getTrustScore(counterpartyAddress)
    API-->>Agent: composite trust score
```

<sub>Reviews (1): Last reviewed commit: ["add: @trustlayer/plugin-elizaos to regis..."](https://github.com/elizaos-plugins/registry/commit/fa2c3da94d2b5010950364fe50c8c18492f884a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27362151)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->