### PR TITLE
Add plugin-signalfuse

### DIFF
--- a/index.json
+++ b/index.json
@@ -353,6 +353,7 @@
   "@elizaos/plugin-zytron": "github:zypher-network/plugin-zytron",
   "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
   "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
+  "@hypeprinter007-stack/plugin-signalfuse": "github:hypeprinter007-stack/plugin-signalfuse",
   "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
   "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
   "@mascotai/plugin-connections": "github:mascotai/plugin-connections",

--- a/index.json
+++ b/index.json
@@ -353,7 +353,7 @@
   "@elizaos/plugin-zytron": "github:zypher-network/plugin-zytron",
   "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
   "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
-  "@hypeprinter007-stack/plugin-signalfuse": "github:hypeprinter007-stack/plugin-signalfuse",
+  "@hypeprinter007/plugin-signalfuse": "github:hypeprinter007-stack/plugin-signalfuse",
   "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
   "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
   "@mascotai/plugin-connections": "github:mascotai/plugin-connections",


### PR DESCRIPTION
Adds [plugin-signalfuse](https://github.com/hypeprinter007-stack/plugin-signalfuse) to the ElizaOS plugin registry.

Gives ElizaOS agents live crypto trading signal awareness — fused sentiment, macro regime, and Hyperliquid market structure from the SignalFuse API.

- **npm:** `plugin-signalfuse@0.1.0`
- **Actions:** GET_TRADING_SIGNAL, GET_MACRO_REGIME, GET_SENTIMENT
- **Provider:** Ambient BTC signal context injected every turn
- **Auth:** SIGNALFUSE_CREDIT_TOKEN in runtime settings
- **Homepage:** https://signalfuse.co

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new plugin mapping for hypeprinter007/plugin-signalfuse to the plugin registry.
  * Restored proper file line ending (trailing newline) for consistent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers `plugin-signalfuse` — a crypto trading signal plugin that fuses sentiment, macro regime, and Hyperliquid market data via the SignalFuse API — by adding one entry to `index.json` and fixing a missing trailing newline. The entry format, `github:` prefix, absent `.git` extension, and alphabetical placement are all correct.

- The registry key `@hypeprinter007-stack/plugin-signalfuse` is scoped, but the PR description advertises the package as unscoped `plugin-signalfuse@0.1.0`. If these don't match the actual npm publish name, the registry generator's npm metadata lookup will silently fail for this entry.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the npm package name scope is confirmed to match the registry key.

The entry format is otherwise correct, but a possible mismatch between the scoped registry key and the unscoped npm package name in the PR description could silently break automated npm metadata generation for this plugin. This warrants a quick confirmation before merging.

index.json — verify the npm package scope (`@hypeprinter007-stack/plugin-signalfuse` vs `plugin-signalfuse`) matches what is actually published on npm.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `@hypeprinter007-stack/plugin-signalfuse` entry and fixes missing trailing newline; registry key scope may not match the published npm package name stated in the PR description. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Registry as elizaOS Registry (index.json)
    participant GH as github:hypeprinter007-stack/plugin-signalfuse
    participant NPM as npm registry
    User->>Registry: Request plugin by key
    Registry->>GH: Fetch plugin source code
    GH-->>Registry: Plugin source
    Registry->>NPM: Lookup metadata by key name<br/>(@hypeprinter007-stack/plugin-signalfuse)
    NPM-->>Registry: Metadata (or 404 if key ≠ publish name)
    Registry-->>User: generated-registry.json entry
```

<sub>Reviews (1): Last reviewed commit: ["Add plugin-signalfuse to registry"](https://github.com/elizaos-plugins/registry/commit/d50040592726b0be1c60b596e229037d19fb867a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27378683)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->