### PR TITLE
Add @madeonsol/plugin-madeonsol

### DIFF
--- a/index.json
+++ b/index.json
@@ -355,6 +355,7 @@
   "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
   "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
   "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
+  "@madeonsol/plugin-madeonsol": "github:LamboPoewert/plugin-madeonsol",
   "@mascotai/plugin-connections": "github:mascotai/plugin-connections",
   "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
   "@nuggetslife/plugin-nuggets": "github:NuggetsLtd/eliza-plugin-nuggets",


### PR DESCRIPTION
## Plugin: @madeonsol/plugin-madeonsol

**npm:** https://www.npmjs.com/package/@madeonsol/plugin-madeonsol
**GitHub:** https://github.com/LamboPoewert/plugin-madeonsol
**Website:** https://madeonsol.com

### What it does

ElizaOS plugin that gives agents access to MadeOnSol's Solana intelligence API — real-time KOL trade tracking (946 wallets), multi-KOL coordination signals, KOL PnL leaderboards, and Pump.fun elite deployer alerts.

### Actions

| Action | Description |
|--------|-------------|
| `GET_KOL_FEED` | Real-time KOL trade feed |
| `GET_KOL_COORDINATION` | Multi-KOL convergence signals |
| `GET_KOL_LEADERBOARD` | KOL PnL/win-rate rankings |
| `GET_DEPLOYER_ALERTS` | Pump.fun elite deployer alerts |

### Authentication

Supports three auth methods: MadeOnSol API key (free), RapidAPI key, or x402 micropayments (for autonomous agents with Solana wallets).

### Demo

Working demo in Cursor with MCP server calling the same API:

![Demo screenshot](https://raw.githubusercontent.com/LamboPoewert/plugin-madeonsol/master/assets/banner.png)

### Branding

![Logo](https://raw.githubusercontent.com/LamboPoewert/plugin-madeonsol/master/assets/logo.png)

### Compatibility

- elizaOS v1.x compatible
- Published on npm as `@madeonsol/plugin-madeonsol@0.3.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new plugin package `@madeonsol/plugin-madeonsol` to the registry, making it available for installation and use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `@madeonsol/plugin-madeonsol` to the ElizaOS plugin registry, pointing to `github:LamboPoewert/plugin-madeonsol`. The plugin provides Solana KOL trade intelligence capabilities (real-time trade feeds, coordination signals, PnL leaderboards, and Pump.fun deployer alerts) to ElizaOS agents.

- The registry entry is correctly alphabetically ordered between `@kudo-dev/plugin-kudo` and `@mascotai/plugin-connections`
- The `github:owner/repo` format (without version pinning) is consistent with the majority of other entries in this registry
- The npm package exists (`@madeonsol/plugin-madeonsol@0.3.0`) and the GitHub repository has proper ElizaOS plugin structure (`agentConfig.pluginType: "elizaos:plugin:1.0.0"`, `@elizaos/core` peer dependency, `elizaos` keyword)
- Minor: the GitHub repo's `package.json` is at version `0.2.0` while the latest npm release is `0.3.0`, suggesting the source repo is slightly behind the published release

<h3>Confidence Score: 4/5</h3>

Safe to merge; the plugin is legitimate and the registry entry is well-formed

Single-line registry addition is correctly formatted and alphabetically placed. The plugin has valid npm and GitHub presence with proper ElizaOS plugin structure. The only concern is a minor version discrepancy (GitHub package.json at 0.2.0 vs npm 0.3.0), which does not block merging.

index.json line 358 — minor version sync note only

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds @madeonsol/plugin-madeonsol registry entry in correct alphabetical order; minor version mismatch between GitHub (0.2.0) and npm (0.3.0) |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ElizaOS Agent] -->|install plugin| B[Registry index.json]
    B -->|github:LamboPoewert/plugin-madeonsol| C[GitHub Repository]
    C --> D[Plugin Actions]
    D --> E[GET_KOL_FEED]
    D --> F[GET_KOL_COORDINATION]
    D --> G[GET_KOL_LEADERBOARD]
    D --> H[GET_DEPLOYER_ALERTS]
    E & F & G & H -->|HTTP requests| I[MadeOnSol API]
    I --> J{Auth Method}
    J --> K[MadeOnSol API Key]
    J --> L[RapidAPI Key]
    J --> M[x402 Micropayments]
```

<sub>Reviews (1): Last reviewed commit: ["Add @madeonsol/plugin-madeonsol — Solana..."](https://github.com/elizaos-plugins/registry/commit/6be652594ae3c38acb17b8e62f7ce1e725ba783f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27393409)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->