### PR TITLE
feat: add @mangoswap/elizaos-plugin — cross-chain swaps for 10+ chains

### DIFF
--- a/index.json
+++ b/index.json
@@ -357,6 +357,7 @@
   "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
   "@mascotai/plugin-connections": "github:mascotai/plugin-connections",
   "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
+  "@mangoswap/elizaos-plugin": "github:0tabris/mangoswap",
   "@nuggetslife/plugin-nuggets": "github:NuggetsLtd/eliza-plugin-nuggets",
   "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai",
   "@proofgate/eliza-plugin": "github:ProofGate/proofgate-eliza-plugin",

--- a/index.json
+++ b/index.json
@@ -357,7 +357,7 @@
   "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
   "@mascotai/plugin-connections": "github:mascotai/plugin-connections",
   "@mazzz/plugin-elizaos-compchembridge": "github:Mazzz-zzz/plugin-elizaos-compchembridge",
-  "@mangoswap/elizaos-plugin": "github:0tabris/mangoswap",
+  "@mangoswapio/elizaos-plugin": "github:0tabris/mangoswap",
   "@nuggetslife/plugin-nuggets": "github:NuggetsLtd/eliza-plugin-nuggets",
   "@onbonsai/plugin-bonsai": "github:onbonsai/plugin-bonsai",
   "@proofgate/eliza-plugin": "github:ProofGate/proofgate-eliza-plugin",


### PR DESCRIPTION
## Plugin: @mangoswap/elizaos-plugin

Cross-chain token swaps via MangoSwap — bridge and swap tokens across 10+ blockchains using natural language.

### What it does

Gives any ElizaOS agent the ability to:
- Get cross-chain swap quotes (`GET_SWAP_QUOTE`)
- Execute cross-chain swaps (`CREATE_CROSS_CHAIN_SWAP`) — requires `MANGO_ALLOW_WRITE=true`
- Check swap status (`GET_SWAP_STATUS`)

### Example

```
User:  "Bridge 0.5 ETH from Base to Arbitrum for 0xAbCd..."
Agent: [GET_SWAP_QUOTE] → [CREATE_CROSS_CHAIN_SWAP]
Agent: "Swap created ✅ — send 0.5 ETH to 0x9BcD...
        You'll receive ~0.498 ETH on Arbitrum in ~4 minutes.
        Swap ID: abc-def-123"
```

### Supported chains

Ethereum · Base · Arbitrum · Optimism · Polygon · BSC · Avalanche · Solana · Bitcoin · TRON

### npm

https://www.npmjs.com/package/@mangoswap/elizaos-plugin

### Repository

https://github.com/0tabris/mangoswap/tree/main/mangoswap/packages/elizaos-plugin

### Checklist

- [x] TypeScript source with full types
- [x] `@elizaos/core` peer dependency
- [x] Actions with `validate()`, `examples`, `similes`
- [x] Structured error handling (`code`, `message`, `retryable`)
- [x] Works without API key (anonymous rate-limited access)
- [x] No secrets or private keys hardcoded
- [x] Only `index.json` modified in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MangoSwap plugin is now available and integrated into the platform, giving users access to additional swapping and plugin-based features.
  * The integration was added without altering existing mappings or removing prior functionality, ensuring a seamless rollout for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single entry to `index.json` registering `@mangoswap/elizaos-plugin`, a cross-chain swap plugin, pointing to `github:0tabris/mangoswap`. Two issues need to be resolved before merge:

- The entry is inserted after `@mazzz/...` but alphabetically `@mangoswap` (`mango`) precedes `@mazzz` (`mazz`) — it must move one line up.
- The GitHub reference targets the monorepo root rather than the plugin's subdirectory (`mangoswap/packages/elizaos-plugin`); the correct specifier should follow the `#branch:path` convention used by other monorepo entries (e.g., `github:0tabris/mangoswap#main:mangoswap/packages/elizaos-plugin`), otherwise automated registry generation will read the wrong `package.json`.

<h3>Confidence Score: 4/5</h3>

Not safe to merge as-is — the monorepo path specifier is missing, which would cause the automated registry generator to read the wrong package.json.

Two P1 findings: incorrect alphabetical placement and a missing subdirectory path in the GitHub reference that would break automated registry generation for a monorepo plugin. Both are straightforward one-line fixes.

index.json — both issues are on line 360.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The change is limited to adding a single JSON key-value entry and does not introduce executable code, secrets, or sensitive data.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds @mangoswap/elizaos-plugin entry, but the entry is out of alphabetical order and the GitHub reference points to the monorepo root rather than the plugin's subdirectory. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[index.json entry merged] --> B[GitHub Action triggers registry generation]
    B --> C{GitHub ref resolves to correct location?}
    C -- "current: github:0tabris/mangoswap (root)" --> D[Reads root package.json\n❌ wrong/missing metadata]
    C -- "needed: github:0tabris/mangoswap#main:mangoswap/packages/elizaos-plugin" --> E[Reads plugin package.json\n✅ correct metadata]
    E --> F[generated-registry.json updated]
    F --> G[Plugin available in elizaOS CLI & web registry]
```

<sub>Reviews (1): Last reviewed commit: ["feat: add @mangoswap/elizaos-plugin — cr..."](https://github.com/elizaos-plugins/registry/commit/8ac9c7817660c40ec6267797aadca5f091fc777b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27764240)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->