### PR TITLE
Add @blueprint.xyz/plugin-solentic

### DIFF
--- a/index.json
+++ b/index.json
@@ -5,6 +5,7 @@
   "@asterpay/plugin-payments": "github:AsterPay/plugin-payments",
   "@bealers/plugin-mattermost": "github:bealers/plugin-mattermost",
   "@blockrun/elizaos-plugin": "github:BlockRunAI/elizaos-plugin-blockrun",
+  "@blueprint.xyz/plugin-solentic": "github:blueprint-infrastructure/plugin-solentic",
   "@coinrailz/plugin-coinrailz": "github:tdnupe3/coinrailz-eliza-plugin",
   "@elizaos/adapter-mongodb": "github:elizaos-plugins/adapter-mongodb",
   "@elizaos/adapter-pglite": "github:elizaos-plugins/adapter-pglite",


### PR DESCRIPTION
## Plugin

- **Name:** `@blueprint.xyz/plugin-solentic`
- **npm:** https://www.npmjs.com/package/@blueprint.xyz/plugin-solentic
- **GitHub:** https://github.com/blueprint-infrastructure/plugin-solentic
- **License:** MIT

## What it does

Native Solana staking for ElizaOS agents — stake, unstake, and withdraw SOL with the Blueprint validator (rank 87, ~429K SOL, 0% commission staking, Jito MEV enabled). ~6% APY expected. Zero custody: the plugin calls the Solentic API (https://solentic.theblueprint.xyz) which returns unsigned transactions; the agent signs locally with its own keypair.

- 5 actions: stake, unstake, withdraw, checkStakeStatus, getValidatorInfo
- 1 provider: stakingInfo (injects portfolio context into conversation state)
- No smart contract risk — direct native delegation
- No API keys required

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers `@blueprint.xyz/plugin-solentic`, a native Solana staking plugin for ElizaOS agents, by adding one entry to `index.json`. The change is correctly formatted and alphabetically ordered; it also opportunistically fixes the sort position of the pre-existing `@elizaos/plugin-ATTPs` entry and adds a missing trailing newline.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, well-formed registry entry with no logic changes.
- The only changed file is index.json. The new entry follows the established `github:org/repo` format, is placed in the correct alphabetical position, and points to a verifiable GitHub organization. The two bonus fixes (ATTPs sort order, trailing newline) are correct improvements with no risk.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `@blueprint.xyz/plugin-solentic` entry in the correct alphabetical position; also corrects the sort position of the pre-existing `@elizaos/plugin-ATTPs` entry (was placed before `plugin-abstract` in ASCII order, now correctly after `plugin-asterai` in case-insensitive order) and adds a missing trailing newline. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as ElizaOS Agent
    participant Plugin as plugin-solentic
    participant API as Solentic API<br/>(solentic.theblueprint.xyz)
    participant Solana as Solana Network

    Agent->>Plugin: stake / unstake / withdraw action
    Plugin->>API: POST /stake (or /unstake, /withdraw)
    API-->>Plugin: Unsigned transaction (base64)
    Plugin->>Agent: Sign with agent keypair
    Agent->>Solana: Broadcast signed transaction
    Solana-->>Agent: Confirmation / tx signature

    Note over Plugin,API: No API keys required<br/>Zero custody — agent signs locally

    Agent->>Plugin: checkStakeStatus / getValidatorInfo
    Plugin->>API: GET /status or /validator
    API-->>Plugin: Stake info / validator metrics
    Plugin-->>Agent: Response injected into context (stakingInfo provider)
```

<sub>Reviews (1): Last reviewed commit: ["Add @blueprint.xyz/plugin-solentic to re..."](https://github.com/elizaos-plugins/registry/commit/98f2a07ba1da6365537297553eb8af1ac1f68135) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28311651)</sub>

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->