### PR TITLE
Add @blueprint.xyz/plugin-solentic

### DIFF
--- a/index.json
+++ b/index.json
@@ -5,6 +5,7 @@
   "@asterpay/plugin-payments": "github:AsterPay/plugin-payments",
   "@bealers/plugin-mattermost": "github:bealers/plugin-mattermost",
   "@blockrun/elizaos-plugin": "github:BlockRunAI/elizaos-plugin-blockrun",
+  "@blueprint.xyz/plugin-solentic": "github:blueprint-infrastructure/plugin-solentic",
   "@coinrailz/plugin-coinrailz": "github:tdnupe3/coinrailz-eliza-plugin",
   "@elizaos/adapter-mongodb": "github:elizaos-plugins/adapter-mongodb",
   "@elizaos/adapter-pglite": "github:elizaos-plugins/adapter-pglite",


### PR DESCRIPTION
## Plugin

- **Name:** `@blueprint.xyz/plugin-solentic`
- **npm:** https://www.npmjs.com/package/@blueprint.xyz/plugin-solentic
- **GitHub:** https://github.com/blueprint-infrastructure/plugin-solentic
- **License:** MIT

## What it does

Native Solana staking for ElizaOS agents — stake, unstake, and withdraw SOL with the Blueprint validator (rank 87, ~429K SOL, 0% commission staking, Jito MEV enabled). ~6% APY expected. Zero custody: the plugin calls the Solentic API (https://solentic.theblueprint.xyz) which returns unsigned transactions; the agent signs locally with its own keypair.

- 5 actions: stake, unstake, withdraw, checkStakeStatus, getValidatorInfo
- 1 provider: stakingInfo (injects portfolio context into conversation state)
- No smart contract risk — direct native delegation
- No API keys required

Replaces #339 (which was opened from a personal fork). Submitting from the Blueprint org fork instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin-solentic is now available as an installable package, providing additional plugin functionality for enhanced project capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single registry entry for `@blueprint.xyz/plugin-solentic`, a native Solana staking plugin for ElizaOS, pointing to `github:blueprint-infrastructure/plugin-solentic`. The change is minimal and correct: only `index.json` is modified, the entry is properly formatted, and it is alphabetically sorted between `@blockrun/elizaos-plugin` and `@coinrailz/plugin-coinrailz`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a single, well-formed registry entry with no structural issues.
- The change is one line in a JSON registry file. The GitHub repository (`blueprint-infrastructure/plugin-solentic`) is confirmed to exist, the format matches the required schema, alphabetical ordering is correct, and no other files are touched.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds one alphabetically-sorted registry entry mapping `@blueprint.xyz/plugin-solentic` to `github:blueprint-infrastructure/plugin-solentic`; format and ordering are correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as ElizaOS Agent
    participant Registry as Plugin Registry (index.json)
    participant GH as GitHub (blueprint-infrastructure/plugin-solentic)
    participant API as Solentic API (solentic.theblueprint.xyz)
    participant Chain as Solana Network

    Agent->>Registry: "Resolve @blueprint.xyz/plugin-solentic"
    Registry-->>Agent: github:blueprint-infrastructure/plugin-solentic
    Agent->>GH: Dynamic plugin load
    GH-->>Agent: Plugin module (stake/unstake/withdraw/status/validatorInfo)
    Agent->>API: Request unsigned transaction (stake/unstake/withdraw)
    API-->>Agent: Unsigned Solana transaction
    Agent->>Chain: "Sign & submit transaction (local keypair)"
    Chain-->>Agent: Transaction confirmation
```

<sub>Reviews (1): Last reviewed commit: ["Add @blueprint.xyz/plugin-solentic to re..."](https://github.com/elizaos-plugins/registry/commit/f2d6e0445bfc3d8e0517e889b2f2f81c547b3c59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28315665)</sub>

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->