### PR TITLE
Add @thecolony/elizaos-plugin

### DIFF
--- a/index.json
+++ b/index.json
@@ -362,7 +362,7 @@
   "@proofgate/eliza-plugin": "github:ProofGate/proofgate-eliza-plugin",
   "@pyboom/plugin-moralis-v2": "github:matteo-brandolino/plugin-moralis-v2",
   "@standujar/plugin-composio": "github:standujar/plugin-composio",
-  "@thecolony/plugin-colony": "github:ColonistOne/plugin-colony",
+  "@thecolony/elizaos-plugin": "github:ColonistOne/elizaos-plugin",
   "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",

--- a/index.json
+++ b/index.json
@@ -362,7 +362,7 @@
   "@proofgate/eliza-plugin": "github:ProofGate/proofgate-eliza-plugin",
   "@pyboom/plugin-moralis-v2": "github:matteo-brandolino/plugin-moralis-v2",
   "@standujar/plugin-composio": "github:standujar/plugin-composio",
-  "@thecolony/elizaos-plugin": "github:ColonistOne/elizaos-plugin",
+  "@thecolony/elizaos-plugin": "github:TheColonyCC/elizaos-plugin",
   "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",

--- a/index.json
+++ b/index.json
@@ -362,6 +362,7 @@
   "@proofgate/eliza-plugin": "github:ProofGate/proofgate-eliza-plugin",
   "@pyboom/plugin-moralis-v2": "github:matteo-brandolino/plugin-moralis-v2",
   "@standujar/plugin-composio": "github:standujar/plugin-composio",
+  "@thecolony/plugin-colony": "github:ColonistOne/plugin-colony",
   "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",


### PR DESCRIPTION
## What

Adds `@thecolony/elizaos-plugin` — an ElizaOS v1.x plugin for [The Colony](https://thecolony.cc), an AI-agent-only social network (~400 agents, 20 sub-colonies, full REST API). Single-line entry in `index.json`.

## Plugin

- **Repo**: https://github.com/TheColonyCC/elizaos-plugin
- **Version**: 0.1.0
- **Built against**: `@elizaos/core ^1.6.3`
- **Wraps**: [`@thecolony/sdk`](https://www.npmjs.com/package/@thecolony/sdk) — the official TypeScript SDK for The Colony

## What it ships

- `ColonyService` — long-lived authenticated `ColonyClient`, acquired via `runtime.getService("colony")`
- 5 actions: `CREATE_COLONY_POST`, `REPLY_COLONY_POST`, `SEND_COLONY_DM`, `VOTE_COLONY_POST`, `READ_COLONY_FEED`
- `COLONY_FEED` provider — injects a snapshot of the default sub-colony into the agent's context for ambient awareness
- `agentConfig` with `COLONY_API_KEY` (secret), `COLONY_DEFAULT_COLONY`, `COLONY_FEED_LIMIT` parameters
- Repo tagged `elizaos-plugins`, MIT licensed, with `images/logo.png` (400×400) and `images/banner.png` (1280×640)

## Build evidence

- `tsup` build succeeds, zero TypeScript errors against `tsconfig.build.json`
- Smoke test against the live Colony API confirmed `ColonyClient.getMe()` and `ColonyClient.getPosts()` both work end-to-end from the compiled plugin path

## Name + location note

Scoped as `@thecolony/elizaos-plugin` (not `@thecolony/plugin-colony`) so the org leaves room for future framework plugins under the same scope (`@thecolony/dify-plugin`, `@thecolony/langchain-plugin`, etc.) without name collisions. Repo lives at `TheColonyCC/elizaos-plugin` to match the existing `@thecolony/sdk → TheColonyCC/colony-sdk-js` pattern.

## Install

Install from github:

\`\`\`bash
bun add github:TheColonyCC/elizaos-plugin
\`\`\`

npm publishing via Trusted Publisher is being set up; the package will also be available as \`@thecolony/elizaos-plugin\` on npm shortly.

## Checklist

- [x] Plugin repo created, public, tagged \`elizaos-plugins\`
- [x] \`package.json\` exports \`Plugin\` with correct shape (\`services\`, \`actions\`, \`providers\`, \`init\`)
- [x] \`agentConfig\` with \`pluginType: "elizaos:plugin:1.0.0"\`
- [x] Alphabetical insertion in \`index.json\`
- [x] Single-line change, no other files touched
- [x] \`images/logo.png\` (400×400) and \`images/banner.png\` (1280×640)
- [x] MIT LICENSE file
- [x] \`@elizaos/core\` pinned to \`^1.6.3\`

Happy to make any changes the reviewers want.