### PR TITLE
Add megalaunch-elizaos-plugin

### DIFF
--- a/index.json
+++ b/index.json
@@ -366,6 +366,7 @@
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
+  "megalaunch-elizaos-plugin": "github:jacksun911/megalaunch-elizaos-plugin",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",


### PR DESCRIPTION
## Plugin: megalaunch-elizaos-plugin

AI-powered token launch on Solana/pump.fun via MegaLaunch.

### Actions
- `LAUNCH_TOKEN` — Launch a meme token with AI-generated art, bundled buys, Jito-powered execution
- `CHECK_LAUNCH_ORDER` — Check order status
- `GET_LAUNCH_PRICING` — Get package pricing (Basic/Premium)

### Links
- npm: [megalaunch-elizaos-plugin](https://www.npmjs.com/package/megalaunch-elizaos-plugin)
- GitHub: [jacksun911/megalaunch-elizaos-plugin](https://github.com/jacksun911/megalaunch-elizaos-plugin)

### Changes
- Added `"megalaunch-elizaos-plugin": "github:jacksun911/megalaunch-elizaos-plugin"` to `index.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new plugin entry to the available plugins registry, enabling access to the megalaunch-elizaos-plugin integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `megalaunch-elizaos-plugin` (an AI-powered Solana/pump.fun token launcher) to the registry's `index.json`. It also incidentally fixes the missing newline at end of file. The JSON format is valid, the GitHub reference uses the correct `github:` prefix without a `.git` suffix, and the new entry is placed in the correct alphabetical position between the `@z…` scoped entries and the `plugin-*` unscoped entries.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only finding is a P2 naming convention note that does not block correctness.

The entry is valid JSON, uses the correct `github:` reference format with no `.git` suffix, and is placed alphabetically correctly. The unscoped key is consistent with a small number of existing registry entries and does not cause a functional breakage. No P0/P1 issues were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `megalaunch-elizaos-plugin` entry with correct GitHub reference format and alphabetical placement; key is unscoped unlike the majority of registry entries, which follow `@org/plugin-name` convention. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: Add megalaunch-elizaos-plugin] --> B[index.json entry added]
    B --> C{GitHub Action triggers\non merge to main}
    C --> D[Fetch GitHub repo metadata\njacksun911/megalaunch-elizaos-plugin]
    D --> E[Fetch npm metadata\nmegalaunch-elizaos-plugin]
    E --> F[Update generated-registry.json]
    F --> G[Plugin available in\nelizaOS CLI & web registry]
    G --> H[Users install via:\nmegalaunch-elizaos-plugin]
```

<sub>Reviews (1): Last reviewed commit: ["Add megalaunch-elizaos-plugin to registr..."](https://github.com/elizaos-plugins/registry/commit/6183012fe4d0f2eedf246f36276c341646a2555c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28716403)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->