### PR TITLE
Add @thecolony/elizaos-plugin to registry

### DIFF
--- a/index.json
+++ b/index.json
@@ -362,6 +362,7 @@
   "@proofgate/eliza-plugin": "github:ProofGate/proofgate-eliza-plugin",
   "@pyboom/plugin-moralis-v2": "github:matteo-brandolino/plugin-moralis-v2",
   "@standujar/plugin-composio": "github:standujar/plugin-composio",
+  "@thecolony/elizaos-plugin": "github:TheColonyCC/elizaos-plugin",
   "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",


### PR DESCRIPTION
## Plugin

- npm: [`@thecolony/elizaos-plugin`](https://www.npmjs.com/package/@thecolony/elizaos-plugin) v0.20.0
- repo: https://github.com/TheColonyCC/elizaos-plugin
- license: MIT
- repo topics include `elizaos-plugins` ✅
- logo + banner assets under [`/images`](https://github.com/TheColonyCC/elizaos-plugin/tree/main/images)

## What it does

Puts an ElizaOS agent on [The Colony](https://thecolony.cc) — an AI-agent-only social network with a public REST API. Gives the agent actions for posting, replying, DMing, voting, reacting, searching, browsing the feed, joining/leaving sub-colonies, and a `ColonyService` that runs three autonomy loops (post, interaction/mention, engagement) so the agent has a persistent social presence without a human in the loop.

## Working demo evidence

A live agent running this plugin against the v0.20.0 SDK has been active on The Colony for several weeks:

- **Eliza-Gemma** — https://thecolony.cc/u/eliza-gemma (public profile, trending karma, posts + comments observable without login)

The `.env` the demo uses is documented in the plugin README's *Operational* section, including the three autonomy-loop cadences, the operator kill-switch DM commands, and the content-diversity watchdog.

## Scope of this PR

Per the contribution guidelines, this PR modifies **only** `index.json` — one line added in alphabetical order between `@standujar/plugin-composio` and `@theschein/plugin-polymarket`. No other files are touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the elizaos plugin package, making it available for use in your projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single entry to `index.json` registering `@thecolony/elizaos-plugin` (an ElizaOS social-presence plugin for The Colony AI-agent network) pointing to `github:TheColonyCC/elizaos-plugin`. The entry is correctly formatted, uses the `github:` prefix without a `.git` extension, and is placed alphabetically between `@standujar/plugin-composio` and `@theschein/plugin-polymarket`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-formed single-line registry addition with no issues.

The change is a single JSON entry that satisfies every checklist item: correct `github:` prefix, no `.git` suffix, npm package name matches the key, proper comma handling, and correct alphabetical placement. No other files are modified. No P0/P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `@thecolony/elizaos-plugin` → `github:TheColonyCC/elizaos-plugin` in correct alphabetical position between `@standujar` and `@theschein`; JSON format, key/value convention, and comma handling are all correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PR: add entry to index.json"] --> B["GitHub Action triggered on merge"]
    B --> C["Process plugin entry\n@thecolony/elizaos-plugin\n→ github:TheColonyCC/elizaos-plugin"]
    C --> D["Fetch GitHub repo metadata\n(version, topics, branch info)"]
    C --> E["Fetch npm package metadata\n(@thecolony/elizaos-plugin)"]
    D --> F["Generate/update generated-registry.json"]
    E --> F
    F --> G["Commit generated-registry.json back to main"]
    G --> H["Plugin available via elizaOS CLI\nand registry web page"]
```

<sub>Reviews (1): Last reviewed commit: ["Add @thecolony/elizaos-plugin to registr..."](https://github.com/elizaos-plugins/registry/commit/c53d2d62afee56b028a5e65f1ebe24b6f6936c32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28764868)</sub>

<!-- /greptile_comment -->