### PR TITLE
Add @holdfastprotocol/eliza-plugin — Solana escrow & reputation for ElizaOS agents

### DIFF
--- a/index.json
+++ b/index.json
@@ -354,6 +354,7 @@
   "@elizaos/plugin-zytron": "github:zypher-network/plugin-zytron",
   "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
   "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
+  "@holdfastprotocol/eliza-plugin": "github:casematelabs/holdfastprotocol",
   "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
   "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
   "@mascotai/plugin-connections": "github:mascotai/plugin-connections",

--- a/index.json
+++ b/index.json
@@ -354,7 +354,7 @@
   "@elizaos/plugin-zytron": "github:zypher-network/plugin-zytron",
   "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
   "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
-  "@holdfastprotocol/eliza-plugin": "npm:@holdfastprotocol/eliza-plugin@devnet",
+  "@holdfastprotocol/eliza-plugin": "github:casematelabs/eliza-plugin",
   "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
   "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
   "@mascotai/plugin-connections": "github:mascotai/plugin-connections",

--- a/index.json
+++ b/index.json
@@ -354,7 +354,7 @@
   "@elizaos/plugin-zytron": "github:zypher-network/plugin-zytron",
   "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
   "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
-  "@holdfastprotocol/eliza-plugin": "github:casematelabs/holdfastprotocol",
+  "@holdfastprotocol/eliza-plugin": "npm:@holdfastprotocol/eliza-plugin@devnet",
   "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
   "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
   "@mascotai/plugin-connections": "github:mascotai/plugin-connections",

--- a/index.json
+++ b/index.json
@@ -354,7 +354,7 @@
   "@elizaos/plugin-zytron": "github:zypher-network/plugin-zytron",
   "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
   "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
-  "@holdfastprotocol/eliza-plugin": "github:casematelabs/eliza-plugin",
+  "@holdfastprotocol/eliza-plugin": "github:casematelabs/holdfastprotocol-eliza-plugin",
   "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
   "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
   "@mascotai/plugin-connections": "github:mascotai/plugin-connections",


### PR DESCRIPTION
## Plugin: `@holdfastprotocol/eliza-plugin`

Adds Holdfast Protocol integration to the elizaOS registry.

### What this plugin does

Holdfast Protocol is a Solana trust infrastructure protocol for autonomous agents. This plugin gives ElizaOS agents native access to:

- **`CHECK_REPUTATION`** — query on-chain `VerifTier` reputation scores for any agent wallet before committing funds
- **`CREATE_PACT` / `DEPOSIT_ESCROW` / `RELEASE_PACT`** — create and settle programmable escrow with `TaskRelease | MilestoneRelease | TimedRelease` conditions
- **`OPEN_DISPUTE`** — initiate on-chain dispute resolution
- **Reputation provider** — injects counterparty reputation scores into the agent's context window
- **Escrow service** — background poller that emits `HOLDFAST_PACT_STATE` events on state transitions

### Links

- **npm:** https://www.npmjs.com/package/@holdfastprotocol/eliza-plugin (`devnet` tag)
- **Plugin repo:** https://github.com/casematelabs/holdfastprotocol-eliza-plugin
- **SDK repo:** https://github.com/casematelabs/holdfastprotocol-sdk
- **Community discussion:** https://github.com/orgs/elizaOS/discussions/7071

### Change

Only `index.json` is modified, per the contribution guidelines.

```json
"@holdfastprotocol/eliza-plugin": "github:casematelabs/holdfastprotocol-eliza-plugin"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Eliza plugin entry to the configuration to enable the Eliza plugin on devnet.

* **Chores**
  * Reformatted the configuration file for consistent JSON styling and readability (whitespace/brace/newline changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR registers `@holdfastprotocol/eliza-plugin` (Solana escrow & reputation) into the elizaOS plugin registry by adding a single `github:` entry to `index.json`. The previous `npm:@holdfastprotocol/eliza-plugin@devnet` reference has been replaced with `github:casematelabs/holdfastprotocol-eliza-plugin`, bringing the entry in line with the `github:` convention used by every other plugin in the registry. The PR description still references a different repository URL (`casematelabs/holdfastprotocol` / npm link) that does not match the committed GitHub reference (`casematelabs/holdfastprotocol-eliza-plugin`); reviewers should confirm the target repository exists and that its root-level `package.json` declares `name: "@holdfastprotocol/eliza-plugin"` before merging.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the target repository `casematelabs/holdfastprotocol-eliza-plugin` is confirmed to exist with a root-level `package.json` declaring the correct package name.

The critical prior issue (mutable `npm:` dist-tag reference) has been resolved by switching to a `github:` reference consistent with the rest of the registry. The entry is alphabetically placed correctly and the file reformatting introduces no content changes. Score is capped at 4 rather than 5 because the referenced GitHub repository (`casematelabs/holdfastprotocol-eliza-plugin`) has not been independently confirmed to exist and expose a root-level `package.json` with the matching package name — a mismatch would silently break registry generation.

index.json — specifically the `github:casematelabs/holdfastprotocol-eliza-plugin` reference; confirm the repository is public and its root `package.json` declares `name: "@holdfastprotocol/eliza-plugin"`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds one new registry entry `@holdfastprotocol/eliza-plugin` pointing to `github:casematelabs/holdfastprotocol-eliza-plugin`, correctly placed in alphabetical order; the whole file was reformatted (trailing newlines normalised) with no other content changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PR: Add @holdfastprotocol/eliza-plugin"] --> B["index.json entry added"]
    B --> C["github:casematelabs/holdfastprotocol-eliza-plugin"]
    C --> D{"Registry build process"}
    D --> E["Fetch package.json from repo root"]
    E --> F{"name == '@holdfastprotocol/eliza-plugin'?"}
    F -- Yes --> G["Entry valid — published to generated-registry.json"]
    F -- No --> H["Build error: package name mismatch"]
    D --> I["Alphabetical position check"]
    I --> J["Between @esscrypt and @kamiyo ✓"]
```

<sub>Reviews (4): Last reviewed commit: ["Update @holdfastprotocol/eliza-plugin to..."](https://github.com/elizaos-plugins/registry/commit/1d92f247ff0b8cfffb2cc4053af7fab2bb08a4d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29323630)</sub>

<!-- /greptile_comment -->