### PR TITLE
feat: add @flipcoin/plugin-elizaos

### DIFF
--- a/index.json
+++ b/index.json
@@ -354,6 +354,7 @@
   "@elizaos/plugin-zytron": "github:zypher-network/plugin-zytron",
   "@erdgecrawl/plugin-base-signals": "github:erdGeclaw/plugin-base-signals",
   "@esscrypt/plugin-polkadot": "github:Esscrypt/plugin-polkadot",
+  "@flipcoin/plugin-elizaos": "github:flipcoin-fun/eliza-plugin-flipcoin",
   "@kamiyo/eliza": "github:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza",
   "@kudo-dev/plugin-kudo": "github:Kudo-Archi/plugin-kudo",
   "@mascotai/plugin-connections": "github:mascotai/plugin-connections",


### PR DESCRIPTION
## Plugin info

- **Package:** [`@flipcoin/plugin-elizaos`](https://www.npmjs.com/package/@flipcoin/plugin-elizaos) (published on npm, v0.1.0)
- **Repo:** https://github.com/flipcoin-fun/eliza-plugin-flipcoin
- **Description:** FlipCoin prediction markets plugin — lets ElizaOS agents browse markets, get quotes, and execute trades on Base
- **Protocol:** [FlipCoin](https://flipcoin.fun) — hybrid LMSR AMM + CLOB on Base
- **License:** MIT

## What this PR does

Adds a single entry to `index.json` (alphabetically sorted between `@esscrypt/plugin-polkadot` and `@kamiyo/eliza`). No other files touched.

```json
"@flipcoin/plugin-elizaos": "github:flipcoin-fun/eliza-plugin-flipcoin"
```

## Checklist

- [x] PR modifies **only** `index.json`
- [x] Entry follows alphabetical sort
- [x] Package published on npm
- [x] Repo public, has README, topics include `elizaos-plugins`
- [x] Valid JSON (validated locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registered the Flipcoin ELIZA plugin, adding it to the available plugin ecosystem and enabling new functionality options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single line to `index.json`, registering `@flipcoin/plugin-elizaos` (a FlipCoin prediction-markets plugin for Base) with a `github:` pointer to its source repo. The entry is alphabetically ordered correctly, follows the existing `"package": "github:owner/repo"` format, and the JSON remains valid.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-formed registry entry with no logic, no security surface, and correct alphabetical placement.

The change is a single-line JSON addition that follows the established registry format exactly. Alphabetical ordering is correct, the JSON is valid, and no other files are touched. No P0/P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds one registry entry `@flipcoin/plugin-elizaos` pointing to `github:flipcoin-fun/eliza-plugin-flipcoin`; correctly alphabetically sorted between `@esscrypt/` and `@kamiyo/`, format matches surrounding entries, valid JSON. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[index.json registry] --> B["@esscrypt/plugin-polkadot\ngithub:Esscrypt/plugin-polkadot"]
    A --> C["@flipcoin/plugin-elizaos NEW\ngithub:flipcoin-fun/eliza-plugin-flipcoin"]
    A --> D["@kamiyo/eliza\ngithub:kamiyo-ai/kamiyo-protocol#main:packages/kamiyo-eliza"]
    C --> E[flipcoin-fun/eliza-plugin-flipcoin\nGitHub repo]
    E --> F[ElizaOS agent\nmarkets / quotes / trades\non Base]
```

<sub>Reviews (1): Last reviewed commit: ["feat: add @flipcoin/plugin-elizaos"](https://github.com/elizaos-plugins/registry/commit/4a21ef63dd9f3beaea535c95814dc5437494ad4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29499726)</sub>

<!-- /greptile_comment -->