### PR TITLE
Add @traderouter/plugin-elizaos

### DIFF
--- a/index.json
+++ b/index.json
@@ -366,6 +366,7 @@
   "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
+  "@traderouter/plugin-elizaos": "github:TradeRouter/plugin-elizaos",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",


### PR DESCRIPTION
Adds the official Trade Router ElizaOS plugin to the registry.

## Plugin

- **Package**: `@traderouter/plugin-elizaos`
- **Source**: <https://github.com/TradeRouter/plugin-elizaos> (MIT)

The plugin spawns the [`@traderouter/trade-router-mcp`](https://github.com/TradeRouter/trade-router-mcp) MCP server as a child process, performs the MCP `initialize` handshake, calls `tools/list` to discover the live tool surface, and registers each Trade Router tool as an ElizaOS Action. ~140-line TypeScript wrapper.

## What ElizaOS agents get

- 21 trading tools (swap, limit, trailing, TWAP, DCA, and 4 combo orders)
- Multi-DEX routing across Raydium, PumpSwap, Orca, Meteora
- MEV-protected execution by default via Jito
- Ed25519-signed `order_filled` callbacks
- Holdings endpoint (most accurate on Solana)
- Private key never leaves the agent

## Format check

- [x] `index.json` is the only file modified
- [x] Single-line addition, alphabetical (between `@tonyflam/plugin-openchat` and `@zane-archer/plugin-aimo-router`)
- [x] JSON syntactically valid
- [x] Plugin GitHub repo exists and is public: <https://github.com/TradeRouter/plugin-elizaos>
- [x] Plugin repo has README, LICENSE (MIT), package.json with `@elizaos/core ^1.0.0` peer dep

## Trust signals (underlying MCP package)

- VirusTotal **0/62** on `@traderouter/trade-router-mcp@1.0.12`
- CI green on Node 18/20/22 with tarball-leak guard
- Branch protection on `main`
- Signed npm publishes
- Already in the official MCP Registry as `ai.traderouter/trade-router-mcp@1.0.12` (`isLatest: true`)
- Glama listing (author-verified): <https://glama.ai/mcp/servers/@traderouter/trade-router-mcp>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new plugin package, extending the available plugin options for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single registry entry for `@traderouter/plugin-elizaos` → `github:TradeRouter/plugin-elizaos` to `index.json`. The entry is syntactically valid JSON, uses the correct `github:Owner/repo` format, and is correctly placed in alphabetical order between `@tonyflam/plugin-openchat` and `@zane-archer/plugin-aimo-router`.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a minimal, correctly formatted single-line registry entry with no structural issues.

The change is a single-line addition to a JSON registry file. Format, alphabetical ordering, and value pattern all match existing entries. No P0 or P1 issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Single-line addition of @traderouter/plugin-elizaos pointing to github:TradeRouter/plugin-elizaos; format, JSON validity, and alphabetical ordering all check out |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as ElizaOS Agent
    participant Plugin as @traderouter/plugin-elizaos
    participant MCP as @traderouter/trade-router-mcp (child process)
    participant DEX as DEX (Raydium/PumpSwap/Orca/Meteora)

    Agent->>Plugin: load plugin
    Plugin->>MCP: spawn child process
    Plugin->>MCP: MCP initialize handshake
    Plugin->>MCP: tools/list
    MCP-->>Plugin: 21 tool definitions
    Plugin-->>Agent: register tools as ElizaOS Actions

    Agent->>Plugin: invoke trade action (e.g. swap)
    Plugin->>MCP: call tool via MCP protocol
    MCP->>DEX: route + execute order (Jito MEV-protected)
    DEX-->>MCP: order_filled (Ed25519-signed callback)
    MCP-->>Plugin: result
    Plugin-->>Agent: action result
```

<sub>Reviews (1): Last reviewed commit: ["Add @traderouter/plugin-elizaos"](https://github.com/elizaos-plugins/registry/commit/5058273c9b7661aa77506911c508880b7fc6c9a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29713349)</sub>

<!-- /greptile_comment -->