### PR TITLE
feat: add @undesirables/plugin-tcg-oracle and plugin-undesirables

### DIFF
--- a/index.json
+++ b/index.json
@@ -372,5 +372,5 @@
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",
   "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402",
-    "plugin-undesirables": "github:sailorpepe/elizaos-tcg-oracle-plugin"
+        "plugin-undesirables": "github:sailorpepe/plugin-undesirables"
 }

--- a/index.json
+++ b/index.json
@@ -366,9 +366,11 @@
   "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
+    "@undesirables/plugin-tcg-oracle": "github:sailorpepe/elizaos-tcg-oracle-plugin",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",
-  "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402"
+  "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402",
+    "plugin-undesirables": "github:sailorpepe/elizaos-tcg-oracle-plugin"
 }

--- a/index.json
+++ b/index.json
@@ -366,11 +366,11 @@
   "@theschein/plugin-polymarket": "github:Okay-Bet/plugin-polymarket",
   "@token-metrics-ai/plugin-tokenmetrics": "github:token-metrics/plugin-tokenmetrics",
   "@tonyflam/plugin-openchat": "github:Tonyflam/plugin-openchat",
-    "@undesirables/plugin-tcg-oracle": "github:sailorpepe/elizaos-tcg-oracle-plugin",
+  "@undesirables/plugin-tcg-oracle": "github:sailorpepe/elizaos-tcg-oracle-plugin",
   "@zane-archer/plugin-aimo-router": "github:takasaki404/plugin-aimo-router",
   "plugin-connections": "github:mascotai/plugin-connections",
   "plugin-moltbazaar": "github:10inchdev/plugin-moltbazaar",
   "plugin-octav": "github:wpoulin/plugin-octav",
   "plugin-otaku-x402": "github:otaku-x402/elizaos-plugin-otaku-x402",
-        "plugin-undesirables": "github:sailorpepe/plugin-undesirables"
+  "plugin-undesirables": "github:sailorpepe/plugin-undesirables"
 }


### PR DESCRIPTION
## Registry Update Checklist

- [x] GitHub URL uses the format `github:owner/repo`
- [x] Entry is placed in alphabetical order in `index.json`
- [x] JSON is valid (no trailing commas, proper formatting)
- [x] Plugin repository has required assets:
  - [x] `README.md` with installation and usage docs
  - [x] `images/logo.jpg` (400x400, <500KB)
  - [x] `images/banner.jpg` (1280x640, <1MB)
  - [x] `elizaos-plugins` GitHub topic
- [x] Plugin is published to npm
- [x] Tests are passing

## Plugins Being Added

### @undesirables/plugin-tcg-oracle
AI-powered trading card market intelligence for ElizaOS agents. Search 370K+ products across 25 games, grade cards with AI vision (PSA/Beckett prediction), and run Monte Carlo price simulations (Heston/Merton/Kou models).

- **npm**: [@undesirables/plugin-tcg-oracle](https://www.npmjs.com/package/@undesirables/plugin-tcg-oracle)
- **GitHub**: [sailorpepe/elizaos-tcg-oracle-plugin](https://github.com/sailorpepe/elizaos-tcg-oracle-plugin)

### plugin-undesirables
Personality-as-Code for ElizaOS agents. Loads verifiable soul workspaces with Big Five psychology, 23 skills (market analysis, portfolio checks, whale tracking, content creation), Business Pilot (23 business automation modules), and Meme Machine.

- **npm**: [plugin-undesirables](https://www.npmjs.com/package/plugin-undesirables)  
- **GitHub**: [sailorpepe/plugin-undesirables](https://github.com/sailorpepe/plugin-undesirables)

## Quality Assurance
- ✅ 25 tests passing (14 TCG + 11 Undesirables)
- ✅ Structured parameters on all 8 actions
- ✅ Environment validation (`environment.ts`)
- ✅ Plugin `init` lifecycle hooks
- ✅ Branding assets (logo.jpg 400x400 + banner.jpg 1280x640)
- ✅ `elizaos-plugins` GitHub topic on both repos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TCG Oracle plugin for card game functionality
  * Added Undesirables plugin for extended capabilities
  * Expanded plugin ecosystem with new package mappings

* **Chores**
  * Updated plugin registry structure and syntax

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two registry entries to `index.json`: `@undesirables/plugin-tcg-oracle` (pointing to `github:sailorpepe/elizaos-tcg-oracle-plugin`) and `plugin-undesirables` (pointing to `github:sailorpepe/plugin-undesirables`). Both previously-flagged issues — duplicate repository targets and inconsistent indentation — have been resolved in this revision.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — both entries are well-formed, correctly ordered, and point to distinct repositories.

No P0 or P1 findings. The two previously flagged issues (duplicate repo target, inconsistent indentation) have both been addressed. Alphabetical ordering is correct for both new entries and the JSON remains valid.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Two registry entries added with correct 2-space indentation, proper alphabetical placement, and distinct GitHub repository targets. No issues found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[index.json Registry] --> B["@undesirables/plugin-tcg-oracle"]
    A --> C["plugin-undesirables"]
    B --> D["github:sailorpepe/elizaos-tcg-oracle-plugin\n(TCG market intelligence, AI card grading)"]
    C --> E["github:sailorpepe/plugin-undesirables\n(Personality-as-Code, soul workspaces)"]
    D --> F["npm: @undesirables/plugin-tcg-oracle"]
    E --> G["npm: plugin-undesirables"]
```

<sub>Reviews (3): Last reviewed commit: ["style: fix indentation to 2 spaces"](https://github.com/elizaos-plugins/registry/commit/69b3d42a09e77298c1a31f568e9cab84d598a73d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29723454)</sub>

<!-- /greptile_comment -->