### PR TITLE
Add @algovoi/plugin-elizaos — multi-chain A2A payments (7 chains)

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,5 +1,6 @@
 {
   "@1BDO/plugin-delta": "github:1BDO/plugin-delta",
+  "@algovoi/plugin-elizaos": "github:chopmob-cloud/elizaos-plugin-algovoi",
   "@andysalvo/plugin-x402-trust": "github:andysalvo/plugin-x402-trust",
   "@arthur-orderly/plugin-arthur-dex": "github:arthur-orderly/arthur-eliza-plugin",
   "@asterpay/plugin-payments": "github:AsterPay/plugin-payments",
@@ -38,7 +39,6 @@
   "@elizaos/plugin-0x": "github:elizaos-plugins/plugin-0x",
   "@elizaos/plugin-3d-generation": "github:elizaos-plugins/plugin-3d-generation",
   "@elizaos/plugin-8004": "github:elizaos-plugins/plugin-8004",
-  "@elizaos/plugin-ATTPs": "github:APRO-com/plugin-ATTPs",
   "@elizaos/plugin-abstract": "github:elizaos-plugins/plugin-abstract",
   "@elizaos/plugin-acp": "github:elizaos-plugins/plugin-acp",
   "@elizaos/plugin-action-bench": "github:elizaos-plugins/plugin-action-bench",
@@ -58,6 +58,7 @@
   "@elizaos/plugin-arkham": "github:elizaos-plugins/plugin-arkham",
   "@elizaos/plugin-arthera": "github:elizaos-plugins/plugin-arthera",
   "@elizaos/plugin-asterai": "github:elizaos-plugins/plugin-asterai",
+  "@elizaos/plugin-ATTPs": "github:APRO-com/plugin-ATTPs",
   "@elizaos/plugin-auto-trader": "github:elizaos-plugins/plugin-auto-trader",
   "@elizaos/plugin-autocoder": "github:elizaos-plugins/plugin-autocoder",
   "@elizaos/plugin-autofun": "github:elizaos-plugins/plugin-autofun",


### PR DESCRIPTION
## What this adds

A single registry entry for `@algovoi/plugin-elizaos` — a non-custodial, multi-chain agent-to-agent (A2A) crypto payments plugin for ElizaOS agents.

```diff
+  "@algovoi/plugin-elizaos": "github:chopmob-cloud/elizaos-plugin-algovoi",
```

Inserted alphabetically between `@1BDO/plugin-delta` and `@andysalvo/plugin-x402-trust`. Only `index.json` is modified.

> **Note on the diff:** the patch also relocates the existing `@elizaos/plugin-ATTPs` entry from between `plugin-8004` and `plugin-abstract` to after `plugin-asterai`. This is an alpha-sort fix — `ATTPs` lower-cases to `attps`, which sorts after `asterai` and before `auto-trader`, so the new position is the correct case-insensitive position. Flagging it explicitly so reviewers don't have to wonder why a second line moved (h/t Greptile review for catching the undocumented secondary change).

## What the plugin does

Lets an Eliza agent **ask for, verify, and poll fiat-denominated crypto payments** across **7 chains** without holding any crypto, keys, or fiat.

| Action | Purpose |
|---|---|
| `CREATE_PAYMENT_REQUEST` | Generate a hosted checkout URL the payer opens in any browser |
| `VERIFY_PAYMENT` | Confirm an on-chain tx satisfies a payment, returns access JWT |
| `CHECK_PAYMENT_STATUS` | Poll a previously-issued checkout token |

Plus one provider (`algovoi`) that surfaces capabilities and configured defaults.

## Why a separate payment plugin

The existing payment-related plugins in the registry (`@elizaos/plugin-coinbase`, `@asterpay/plugin-payments`, `@elizaos/plugin-okto`, `@elizaos/plugin-payai`, `@elizaos/plugin-jupiter`, `@elizaos/plugin-raydium`, `@elizaos/plugin-solana`, `@elizaos/plugin-evm`) cover individual chains, custodial flows, or DEX swaps. None offer a single non-custodial gateway that:

- Settles on **all 7** of Algorand, VOI, Hedera, Stellar, Base, Solana, **and** Tempo from one plugin
- Speaks **all 4** of x402, MPP (IETF), AP2 (Google Agentic Payments), **and** Google A2A v0.3
- Accepts **fiat-denominated** input (the agent says "GBP 9.99", AlgoVoi handles chain selection and microunit conversion)
- Holds **no funds** — settlement is direct customer-wallet to merchant-wallet on a public blockchain

Quote from the AlgoVoi A2A agent card (verifiable at https://api1.ilovechicken.co.uk/.well-known/agent.json):

> Multi-chain, multi-protocol crypto payment verification agent. Verifies on-chain payments (Algorand, VOI, Hedera, Stellar, Base, Solana, Tempo) and gates access to resources using x402, MPP (IETF), or AP2 (Google Agentic Payments) protocols.

## Quality checklist

- [x] Plugin source: https://github.com/chopmob-cloud/elizaos-plugin-algovoi
- [x] Repository topic `elizaos-plugins` set
- [x] `package.json` includes `agentConfig` with `pluginType`, `pluginParameters`, `actions`, `providers`
- [x] Repository field uses `github:chopmob-cloud/elizaos-plugin-algovoi` shortcut
- [x] `images/logo.jpg` 400x400px (12.8 KB, well under 500KB limit)
- [x] `images/banner.jpg` 1280x640px (59.2 KB, well under 1MB limit)
- [x] README documents environment variables, install, usage, supported chains
- [x] Example character config at `examples/payments-character.json`
- [x] MIT licensed
- [x] TypeScript with full type definitions emitted (`dist/index.d.ts`)
- [x] Tests passing: 10/10 (vitest)
- [x] Build clean: tsup ESM + .d.ts, ~19 KB minified bundle

## Working demo evidence

- **Live A2A endpoint** the plugin wraps: https://api1.ilovechicken.co.uk/.well-known/agent.json (Google A2A v0.3 compliant agent card, public — no auth required to read)
- **Test output**: 10/10 tests passing, captured in repo CI configuration
- **Example character**: `examples/payments-character.json` shows the full integration — drop the plugin into any 1.x-compatible Eliza character with a tenant API key and the three actions register on the runtime

## Configuration

```env
ALGOVOI_API_KEY=algvk_live_...        # required — free at dash.algovoi.co.uk/signup
ALGOVOI_API_BASE=https://api1.ilovechicken.co.uk   # default
ALGOVOI_DEFAULT_NETWORK=algorand_mainnet           # default
ALGOVOI_DEFAULT_CURRENCY=GBP                       # default
```

## Compatibility

- ElizaOS `^0.25.0 || ^1.0.0` (peer dependency)
- Node `>=20`
- Pure ESM
- Zero runtime deps beyond `zod` (`@elizaos/core` is a peer)
- No native bindings, no chain-specific SDKs

## Links

- Plugin source: https://github.com/chopmob-cloud/elizaos-plugin-algovoi
- AlgoVoi platform: https://algovoi.co.uk
- AlgoVoi docs: https://docs.algovoi.co.uk
- AlgoVoi compliance hub: https://algovoi.co.uk/AlgoVoi/compliance.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new plugin integration, expanding available options and functionality for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single registry entry mapping `@algovoi/plugin-elizaos` to `github:chopmob-cloud/elizaos-plugin-algovoi`, a multi-chain A2A payments plugin. The new entry is correctly placed alphabetically, uses the standard `github:owner/repo` format, and the referenced repository appears to be a legitimate third-party ElizaOS plugin. The diff also silently relocates `@elizaos/plugin-ATTPs` to its case-insensitively correct alphabetical slot, which is a valid fix but is not mentioned in the PR description.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the single new registry entry is correctly formatted and alphabetically placed, with only a P2 style note about an undocumented secondary sort fix.

Only P2 findings present — the new entry follows all registry conventions, the GitHub shorthand format is correct, and the alphabetical insertion is accurate. The undocumented relocation of `@elizaos/plugin-ATTPs` is a legitimate fix but should be disclosed in the PR description.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.json | Adds `@algovoi/plugin-elizaos` entry pointing to `github:chopmob-cloud/elizaos-plugin-algovoi` in the correct alphabetical position; also silently fixes the sort position of `@elizaos/plugin-ATTPs` (undocumented in PR description). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as ElizaOS Agent
    participant Plugin as @algovoi/plugin-elizaos
    participant API as AlgoVoi API
    participant Chain as On-chain Network
    participant Payer as End-User Payer

    Agent->>Plugin: CREATE_PAYMENT_REQUEST(amount, currency)
    Plugin->>API: POST /payment-request (ALGOVOI_API_KEY)
    API-->>Plugin: { checkoutUrl, token }
    Plugin-->>Agent: Hosted checkout URL + token

    Agent->>Payer: Share checkout URL
    Payer->>Chain: Send crypto to merchant wallet (direct)

    Agent->>Plugin: VERIFY_PAYMENT(token, txId)
    Plugin->>API: POST /verify (token, txId)
    API->>Chain: Confirm on-chain tx
    Chain-->>API: tx status
    API-->>Plugin: { verified: true, accessJwt }
    Plugin-->>Agent: Access JWT

    Agent->>Plugin: CHECK_PAYMENT_STATUS(token)
    Plugin->>API: GET /status (token)
    API-->>Plugin: { status: pending|complete|expired }
    Plugin-->>Agent: Current status
```

<sub>Reviews (1): Last reviewed commit: ["Add @algovoi/plugin-elizaos"](https://github.com/elizaos-plugins/registry/commit/4406d77172b50d039e8cff354735c56e515266d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29782303)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
